### PR TITLE
fix: move RS instance/mesh cleanup before worker thread join in exit_tree

### DIFF
--- a/.agents/skills/compare-csharp-rust/SKILL.md
+++ b/.agents/skills/compare-csharp-rust/SKILL.md
@@ -1,0 +1,111 @@
+````skill
+---
+name: compare-csharp-rust
+description: Compare C# and Rust implementation output by capturing screenshots of matching scenes, then diffing them pixel-by-pixel with Python. Use for visual regression, parity validation, and refactor correctness checks.
+---
+
+## Purpose
+
+Use this skill to verify that the Rust implementation produces visually equivalent output to the C# implementation. It captures screenshots of matching scene pairs, compares them pixel-by-pixel, and reports differences.
+
+Keywords: compare, C#, Rust, screenshot diff, pixel comparison, parity, regression, visual test.
+
+## Scene pairs
+
+The project has matching scene pairs for each implementation:
+
+| C# scene                                    | Rust scene                                    |
+|----------------------------------------------|-----------------------------------------------|
+| `res://scenes/celestial_csharp_demo.tscn`    | `res://scenes/celestial_rust_demo.tscn`       |
+| `res://scenes/celestial_csharp_aggressive.tscn` | `res://scenes/celestial_rust_aggressive.tscn` |
+
+## Prerequisites
+
+- Python 3 with Pillow (`pip install Pillow`).
+- The `godot-screenshot-scene` skill's infrastructure (`debug/run_scene_with_screenshot.sh`).
+- Both C# and Rust implementations built and ready.
+
+## Steps
+
+### 1. Build
+
+```bash
+dotnet build
+```
+
+### 2. Capture C# screenshot
+
+```bash
+./debug/run_scene_with_screenshot.sh \
+  "res://scenes/celestial_csharp_aggressive.tscn" \
+  --delay 5 \
+  --screenshot "$PWD/debug/logs/screenshots/csharp_aggressive.png"
+```
+
+### 3. Capture Rust screenshot
+
+```bash
+./debug/run_scene_with_screenshot.sh \
+  "res://scenes/celestial_rust_aggressive.tscn" \
+  --delay 5 \
+  --screenshot "$PWD/debug/logs/screenshots/rust_aggressive.png"
+```
+
+### 4. Compare with Python
+
+```bash
+python3 -c "
+from PIL import Image
+import sys
+
+rust = Image.open('debug/logs/screenshots/rust_aggressive.png')
+csharp = Image.open('debug/logs/screenshots/csharp_aggressive.png')
+
+print(f'Rust size: {rust.size}')
+print(f'C# size: {csharp.size}')
+
+if rust.size != csharp.size:
+    print('ERROR: Image sizes differ — cannot compare.')
+    sys.exit(1)
+
+r_pixels = list(rust.getdata())
+c_pixels = list(csharp.getdata())
+diffs = 0
+max_diff = 0
+for r, c in zip(r_pixels, c_pixels):
+    d = sum(abs(a - b) for a, b in zip(r, c))
+    if d > 0:
+        diffs += 1
+        max_diff = max(max_diff, d)
+total = len(r_pixels)
+pct = 100.0 * diffs / total
+print(f'Different pixels: {diffs} / {total} ({pct:.2f}%)')
+print(f'Max channel diff sum: {max_diff}')
+if pct > 10:
+    print('WARN: Large difference detected — implementations may diverge.')
+"
+```
+
+Replace `aggressive` with `demo` for the demo scene pair.
+
+## Agent checklist
+
+1. Ensure both scene files exist for the chosen pair.
+2. Build with `dotnet build`.
+3. Capture the C# screenshot (use `godot-screenshot-scene` skill).
+4. Capture the Rust screenshot.
+5. Check both logs for crashes or errors (`handle_crash`, `signal 11`, etc.).
+6. Run the Python pixel comparison.
+7. Report results: image sizes, different pixel count/percentage, max channel diff.
+8. Flag if either run crashed (the screenshot may still be usable if captured before the crash).
+
+## Output to report
+
+- C# benchmark lines (e.g. `Mesh Triangles:`, `Completed in ... ms`).
+- Rust benchmark lines.
+- Whether either run crashed.
+- Image sizes.
+- Different pixels: count, percentage.
+- Max channel diff sum.
+- Pass/fail assessment (< 5% diff is generally acceptable for floating-point differences).
+````

--- a/.vscode/tasks.json
+++ b/.vscode/tasks.json
@@ -1,24 +1,20 @@
-
 {
     "version": "2.0.0",
     "tasks": [
         {
             "label": "build",
-            "command": "dotnet",
             "type": "shell",
+            "command": "cargo",
             "args": [
-                "build",
-                "/property:GenerateFullPaths=true",
-                "/consoleloggerparameters:NoSummary"
+                "build"
             ],
-            "group": {
-                "kind": "build",
-                "isDefault": true
+            "options": {
+                "cwd": "${workspaceFolder}/rust"
             },
             "presentation": {
                 "reveal": "silent"
             },
-            "problemMatcher": "$msCompile"
-        }
+            "problemMatcher": "$rustc"
+        },
     ]
 }

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -72,3 +72,4 @@ dotnet build
 
 - `godot-start-scene`: start Godot scenes through CLI and collect benchmark logs.
 - `godot-screenshot-scene`: generate a wrapper scene that captures viewport screenshot after N seconds, then run it through the logging script.
+- `compare-csharp-rust`: capture screenshots of matching C# and Rust scenes, then diff them pixel-by-pixel with Python to validate parity.

--- a/addons/celestial_sim_rust/shaders/ces_final_state_compositor.glsl
+++ b/addons/celestial_sim_rust/shaders/ces_final_state_compositor.glsl
@@ -1,0 +1,72 @@
+// Shader for CesFinalStateCompositor (scene-space)
+
+#[vertex]
+#version 450
+
+layout(set = 0, binding = 0, std430) readonly buffer Vertices {
+    vec4 positions[];
+};
+
+layout(set = 0, binding = 1, std430) readonly buffer Triangles {
+    uvec4 tris[];
+};
+
+layout(push_constant) uniform PushConstants {
+    mat4 model;
+    mat4 view;
+    mat4 projection;
+    vec4 light_dir;    // xyz = direction (view space), w = intensity
+    vec4 light_color;  // rgb = color, a = ambient
+    vec4 base_color;   // rgb = base color, a unused
+} pc;
+
+layout(location = 0) flat out vec3 frag_normal;
+
+void main() {
+    uint tri_id = gl_VertexIndex / 3u;
+    uint corner = gl_VertexIndex % 3u;
+
+    uvec4 tri = tris[tri_id];
+    vec3 v0 = positions[tri.x].xyz;
+    vec3 v1 = positions[tri.y].xyz;
+    vec3 v2 = positions[tri.z].xyz;
+
+    vec3 pos = (corner == 0u) ? v0 : ((corner == 1u) ? v1 : v2);
+    vec3 face_normal = normalize(cross(v1 - v0, v2 - v0));
+
+    mat3 normal_matrix = mat3(transpose(inverse(pc.view * pc.model)));
+    frag_normal = normalize(normal_matrix * face_normal);
+
+    vec4 world_pos = pc.model * vec4(pos, 1.0);
+    vec4 view_pos = pc.view * world_pos;
+    gl_Position = pc.projection * view_pos;
+}
+
+#[fragment]
+#version 450
+
+layout(location = 0) out vec4 frag_color;
+
+layout(location = 0) flat in vec3 frag_normal;
+
+layout(push_constant) uniform PushConstants {
+    mat4 model;
+    mat4 view;
+    mat4 projection;
+    vec4 light_dir;
+    vec4 light_color;
+    vec4 base_color;
+} pc;
+
+void main() {
+    vec3 n = normalize(frag_normal);
+    vec3 light_dir = normalize(pc.light_dir.xyz);
+    float intensity = pc.light_dir.w;
+    float ambient = pc.light_color.a;
+
+    float diff = max(dot(n, light_dir), 0.0);
+    vec3 color = pc.light_color.rgb * (ambient + diff * intensity);
+    color += pc.base_color.rgb * ambient;
+
+    frag_color = vec4(color, 1.0);
+}

--- a/project.godot
+++ b/project.godot
@@ -15,7 +15,7 @@ compatibility/default_parent_skeleton_in_mesh_instance_3d=true
 [application]
 
 config/name="CelestialSim"
-run/main_scene="uid://dtaqwgacj7mb7"
+run/main_scene="uid://lsbmxhal4svm"
 config/features=PackedStringArray("4.6", "C#", "Forward Plus")
 
 [dotnet]

--- a/rust/Cargo.lock
+++ b/rust/Cargo.lock
@@ -111,6 +111,7 @@ dependencies = [
  "godot",
  "naga",
  "pollster",
+ "serde_json",
  "wgpu",
 ]
 
@@ -439,6 +440,12 @@ dependencies = [
  "equivalent",
  "hashbrown 0.16.1",
 ]
+
+[[package]]
+name = "itoa"
+version = "1.0.17"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "92ecc6618181def0457392ccd0ee51198e065e016d1d527a7ac1b6dc7c1f09d2"
 
 [[package]]
 name = "jni-sys"
@@ -782,6 +789,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "94143f37725109f92c262ed2cf5e59bce7498c01bcc1502d7b9afe439a4e9f49"
 
 [[package]]
+name = "serde"
+version = "1.0.228"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9a8e94ea7f378bd32cbbd37198a4a91436180c5bb472411e48b5ec2e2124ae9e"
+dependencies = [
+ "serde_core",
+]
+
+[[package]]
 name = "serde_core"
 version = "1.0.228"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -799,6 +815,19 @@ dependencies = [
  "proc-macro2",
  "quote",
  "syn",
+]
+
+[[package]]
+name = "serde_json"
+version = "1.0.149"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "83fc039473c5595ace860d8c4fafa220ff474b3fc6bfdb4293327f1a37e94d86"
+dependencies = [
+ "itoa",
+ "memchr",
+ "serde",
+ "serde_core",
+ "zmij",
 ]
 
 [[package]]
@@ -1288,3 +1317,9 @@ name = "xml-rs"
 version = "0.8.28"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3ae8337f8a065cfc972643663ea4279e04e7256de865aa66fe25cec5fb912d3f"
+
+[[package]]
+name = "zmij"
+version = "1.0.21"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b8848ee67ecc8aedbaf3e4122217aff892639231befc6a1b58d29fff4c2cabaa"

--- a/rust/Cargo.toml
+++ b/rust/Cargo.toml
@@ -7,7 +7,9 @@ edition = "2021"
 crate-type = ["cdylib"]
 
 [dependencies]
-godot = { git = "https://github.com/godot-rust/gdext", branch = "master" }
+godot = { git = "https://github.com/godot-rust/gdext", branch = "master", features = [
+    "experimental-threads",
+] }
 bytemuck = { version = "1", features = ["derive"] }
 
 [dev-dependencies]

--- a/rust/Cargo.toml
+++ b/rust/Cargo.toml
@@ -17,3 +17,8 @@ wgpu = "24"
 pollster = "0.4"
 naga = { version = "24", features = ["spv-in", "wgsl-out"] }
 serde_json = "1"
+
+[profile.release]
+debug = true
+strip = false           # Don't remove the info perf needs
+split-debuginfo = "off" # Keep symbols in the binary for easier perf access

--- a/rust/Cargo.toml
+++ b/rust/Cargo.toml
@@ -14,3 +14,4 @@ bytemuck = { version = "1", features = ["derive"] }
 wgpu = "24"
 pollster = "0.4"
 naga = { version = "24", features = ["spv-in", "wgsl-out"] }
+serde_json = "1"

--- a/rust/Cargo.toml
+++ b/rust/Cargo.toml
@@ -9,6 +9,7 @@ crate-type = ["cdylib"]
 [dependencies]
 godot = { git = "https://github.com/godot-rust/gdext", branch = "master", features = [
     "experimental-threads",
+    "experimental-godot-api",
 ] }
 bytemuck = { version = "1", features = ["derive"] }
 

--- a/rust/src/algo/compact_buffers.rs
+++ b/rust/src/algo/compact_buffers.rs
@@ -1,4 +1,5 @@
 use godot::classes::RenderingDevice;
+use godot::obj::Gd;
 
 use crate::buffer_info::BufferInfo;
 use crate::compute_utils;
@@ -16,7 +17,7 @@ const REMAP_TRI_VERTS_SHADER: &str =
 /// Mirrors C# `CesCompactBuffers.Compact()`.
 ///
 /// Returns 0 if nothing was compacted, otherwise returns the count of compacted items.
-pub fn compact(rd: &mut RenderingDevice, state: &mut CesState) -> u32 {
+pub fn compact(rd: &mut Gd<RenderingDevice>, state: &mut CesState) -> u32 {
     // --- Phase A: Compact Triangles ---
     let mut deactivated: Vec<i32> = compute_utils::convert_buffer_to_vec(rd, &state.t_deactivated);
 
@@ -114,12 +115,12 @@ pub fn compact(rd: &mut RenderingDevice, state: &mut CesState) -> u32 {
         std::mem::replace(&mut state.t_deactivated, t_deactivated_dst),
     ];
     for buf in &old_bufs {
-        rd.free_rid(buf.rid);
+        compute_utils::free_rid_on_render_thread(rd, buf.rid);
     }
 
-    rd.free_rid(active_prefix_buf.rid);
-    rd.free_rid(n_tris_total_buf.rid);
-    rd.free_rid(active_count_buf.rid);
+    compute_utils::free_rid_on_render_thread(rd, active_prefix_buf.rid);
+    compute_utils::free_rid_on_render_thread(rd, n_tris_total_buf.rid);
+    compute_utils::free_rid_on_render_thread(rd, active_count_buf.rid);
 
     state.n_tris = active_count;
     state.n_deactivated_tris = 0;
@@ -129,7 +130,7 @@ pub fn compact(rd: &mut RenderingDevice, state: &mut CesState) -> u32 {
         rd,
         std::mem::size_of::<i32>() as u32 * state.n_verts,
     );
-    rd.buffer_clear(vert_active_mask_buf.rid, 0, vert_active_mask_buf.filled_size);
+    compute_utils::buffer_clear_on_render_thread(rd, vert_active_mask_buf.rid, 0, vert_active_mask_buf.filled_size);
 
     let n_tris_uniform = compute_utils::create_uniform_buffer(rd, &state.n_tris);
     let n_verts_uniform = compute_utils::create_uniform_buffer(rd, &state.n_verts);
@@ -144,8 +145,8 @@ pub fn compact(rd: &mut RenderingDevice, state: &mut CesState) -> u32 {
 
     compute_utils::dispatch_shader(rd, MARK_ACTIVE_VERTS_SHADER, &mark_buffers, state.n_tris);
 
-    rd.free_rid(n_tris_uniform.rid);
-    rd.free_rid(n_verts_uniform.rid);
+    compute_utils::free_rid_on_render_thread(rd, n_tris_uniform.rid);
+    compute_utils::free_rid_on_render_thread(rd, n_verts_uniform.rid);
 
     let mut vert_mask: Vec<i32> = compute_utils::convert_buffer_to_vec(rd, &vert_active_mask_buf);
     compute_utils::sum_array_in_place(&mut vert_mask, false);
@@ -197,8 +198,8 @@ pub fn compact(rd: &mut RenderingDevice, state: &mut CesState) -> u32 {
         // Swap vertex buffers
         let old_v_pos = std::mem::replace(&mut state.v_pos, v_pos_dst);
         let old_v_mask = std::mem::replace(&mut state.v_update_mask, v_update_mask_dst);
-        rd.free_rid(old_v_pos.rid);
-        rd.free_rid(old_v_mask.rid);
+        compute_utils::free_rid_on_render_thread(rd, old_v_pos.rid);
+        compute_utils::free_rid_on_render_thread(rd, old_v_mask.rid);
 
         state.n_verts = active_verts_count;
 
@@ -228,16 +229,16 @@ pub fn compact(rd: &mut RenderingDevice, state: &mut CesState) -> u32 {
         );
 
         let old_t_abc = std::mem::replace(&mut state.t_abc, t_abc_remapped);
-        rd.free_rid(old_t_abc.rid);
+        compute_utils::free_rid_on_render_thread(rd, old_t_abc.rid);
 
-        rd.free_rid(n_tris_remap_buf.rid);
-        rd.free_rid(active_verts_remap_buf.rid);
-        rd.free_rid(vert_prefix_buf.rid);
-        rd.free_rid(n_verts_total_buf.rid);
-        rd.free_rid(active_verts_count_buf.rid);
+        compute_utils::free_rid_on_render_thread(rd, n_tris_remap_buf.rid);
+        compute_utils::free_rid_on_render_thread(rd, active_verts_remap_buf.rid);
+        compute_utils::free_rid_on_render_thread(rd, vert_prefix_buf.rid);
+        compute_utils::free_rid_on_render_thread(rd, n_verts_total_buf.rid);
+        compute_utils::free_rid_on_render_thread(rd, active_verts_count_buf.rid);
     }
 
-    rd.free_rid(vert_active_mask_buf.rid);
+    compute_utils::free_rid_on_render_thread(rd, vert_active_mask_buf.rid);
 
     active_count
 }

--- a/rust/src/algo/compact_buffers.rs
+++ b/rust/src/algo/compact_buffers.rs
@@ -3,244 +3,258 @@ use godot::obj::Gd;
 
 use crate::buffer_info::BufferInfo;
 use crate::compute_utils;
+use crate::compute_utils::ComputePipeline;
 use crate::state::CesState;
 
 const COMPACT_TRIS_SHADER: &str = "res://addons/celestial_sim_rust/shaders/CompactTris.slang";
 const MARK_ACTIVE_VERTS_SHADER: &str =
     "res://addons/celestial_sim_rust/shaders/MarkActiveVertices.slang";
-const COMPACT_VERTS_SHADER: &str =
-    "res://addons/celestial_sim_rust/shaders/CompactVertices.slang";
+const COMPACT_VERTS_SHADER: &str = "res://addons/celestial_sim_rust/shaders/CompactVertices.slang";
 const REMAP_TRI_VERTS_SHADER: &str =
     "res://addons/celestial_sim_rust/shaders/RemapTriangleVertices.slang";
 
-/// Compacts deactivated triangles and unused vertices from the mesh buffers.
-/// Mirrors C# `CesCompactBuffers.Compact()`.
-///
-/// Returns 0 if nothing was compacted, otherwise returns the count of compacted items.
-pub fn compact(rd: &mut Gd<RenderingDevice>, state: &mut CesState) -> u32 {
-    // --- Phase A: Compact Triangles ---
-    let mut deactivated: Vec<i32> = compute_utils::convert_buffer_to_vec(rd, &state.t_deactivated);
+pub struct CompactShaders {
+    compact_tris: ComputePipeline,
+    mark_active_verts: ComputePipeline,
+    compact_verts: ComputePipeline,
+    remap_tri_verts: ComputePipeline,
+}
 
-    // Prefix sum inverted: count active (non-deactivated) triangles
-    compute_utils::sum_array_in_place(&mut deactivated, true);
-
-    let active_count = if deactivated.is_empty() {
-        0u32
-    } else {
-        deactivated[deactivated.len() - 1] as u32
-    };
-
-    if active_count == 0 || active_count == state.n_tris {
-        return 0;
+impl CompactShaders {
+    pub fn new(rd: &mut Gd<RenderingDevice>) -> Self {
+        Self {
+            compact_tris: ComputePipeline::new(rd, COMPACT_TRIS_SHADER),
+            mark_active_verts: ComputePipeline::new(rd, MARK_ACTIVE_VERTS_SHADER),
+            compact_verts: ComputePipeline::new(rd, COMPACT_VERTS_SHADER),
+            remap_tri_verts: ComputePipeline::new(rd, REMAP_TRI_VERTS_SHADER),
+        }
     }
 
-    let active_prefix_buf = compute_utils::create_storage_buffer(rd, &deactivated);
+    /// Compacts deactivated triangles and unused vertices from the mesh buffers.
+    /// Mirrors C# `CesCompactBuffers.Compact()`.
+    ///
+    /// Returns 0 if nothing was compacted, otherwise returns the count of compacted items.
+    pub fn compact(&self, rd: &mut Gd<RenderingDevice>, state: &mut CesState) -> u32 {
+        // --- Phase A: Compact Triangles ---
+        let mut deactivated: Vec<i32> =
+            compute_utils::convert_buffer_to_vec(rd, &state.t_deactivated);
 
-    // Create 15 destination buffers for compacted triangle data
-    let tri_elem_size = std::mem::size_of::<i32>() as u32;
-    let dst_byte_size = tri_elem_size * active_count;
-    let t_abc_dst = compute_utils::create_empty_storage_buffer(rd, 4 * tri_elem_size * active_count);
-    let t_divided_dst = compute_utils::create_empty_storage_buffer(rd, dst_byte_size);
-    let t_lv_dst = compute_utils::create_empty_storage_buffer(rd, dst_byte_size);
-    let t_to_div_dst = compute_utils::create_empty_storage_buffer(rd, dst_byte_size);
-    let t_to_merge_dst = compute_utils::create_empty_storage_buffer(rd, dst_byte_size);
-    let t_ico_idx_dst = compute_utils::create_empty_storage_buffer(rd, dst_byte_size);
-    let t_neigh_ab_dst = compute_utils::create_empty_storage_buffer(rd, dst_byte_size);
-    let t_neigh_bc_dst = compute_utils::create_empty_storage_buffer(rd, dst_byte_size);
-    let t_neigh_ca_dst = compute_utils::create_empty_storage_buffer(rd, dst_byte_size);
-    let t_a_t_dst = compute_utils::create_empty_storage_buffer(rd, dst_byte_size);
-    let t_b_t_dst = compute_utils::create_empty_storage_buffer(rd, dst_byte_size);
-    let t_c_t_dst = compute_utils::create_empty_storage_buffer(rd, dst_byte_size);
-    let t_center_t_dst = compute_utils::create_empty_storage_buffer(rd, dst_byte_size);
-    let t_parent_dst = compute_utils::create_empty_storage_buffer(rd, dst_byte_size);
-    let t_deactivated_dst = compute_utils::create_empty_storage_buffer(rd, dst_byte_size);
+        // Prefix sum inverted: count active (non-deactivated) triangles
+        compute_utils::sum_array_in_place(&mut deactivated, true);
 
-    let n_tris_total_buf = compute_utils::create_uniform_buffer(rd, &state.n_tris);
-    let active_count_buf = compute_utils::create_uniform_buffer(rd, &active_count);
+        let active_count = if deactivated.is_empty() {
+            0u32
+        } else {
+            deactivated[deactivated.len() - 1] as u32
+        };
 
-    let buffers: Vec<&BufferInfo> = vec![
-        &state.t_deactivated,   // 0
-        &active_prefix_buf,     // 1
-        &state.t_abc,           // 2
-        &state.t_divided,       // 3
-        &state.t_lv,            // 4
-        &state.t_to_divide_mask, // 5
-        &state.t_to_merge_mask, // 6
-        &state.t_ico_idx,       // 7
-        &state.t_neight_ab,     // 8
-        &state.t_neight_bc,     // 9
-        &state.t_neight_ca,     // 10
-        &state.t_a_t,           // 11
-        &state.t_b_t,           // 12
-        &state.t_c_t,           // 13
-        &state.t_center_t,      // 14
-        &state.t_parent,        // 15
-        &t_abc_dst,             // 16
-        &t_divided_dst,         // 17
-        &t_lv_dst,              // 18
-        &t_to_div_dst,          // 19
-        &t_to_merge_dst,        // 20
-        &t_ico_idx_dst,         // 21
-        &t_neigh_ab_dst,        // 22
-        &t_neigh_bc_dst,        // 23
-        &t_neigh_ca_dst,        // 24
-        &t_a_t_dst,             // 25
-        &t_b_t_dst,             // 26
-        &t_c_t_dst,             // 27
-        &t_center_t_dst,        // 28
-        &t_parent_dst,          // 29
-        &t_deactivated_dst,     // 30
-        &n_tris_total_buf,      // 31
-        &active_count_buf,      // 32
-    ];
-
-    compute_utils::dispatch_shader(rd, COMPACT_TRIS_SHADER, &buffers, state.n_tris);
-
-    // Swap old buffers with compacted ones, free old
-    let old_bufs = [
-        std::mem::replace(&mut state.t_abc, t_abc_dst),
-        std::mem::replace(&mut state.t_divided, t_divided_dst),
-        std::mem::replace(&mut state.t_lv, t_lv_dst),
-        std::mem::replace(&mut state.t_to_divide_mask, t_to_div_dst),
-        std::mem::replace(&mut state.t_to_merge_mask, t_to_merge_dst),
-        std::mem::replace(&mut state.t_ico_idx, t_ico_idx_dst),
-        std::mem::replace(&mut state.t_neight_ab, t_neigh_ab_dst),
-        std::mem::replace(&mut state.t_neight_bc, t_neigh_bc_dst),
-        std::mem::replace(&mut state.t_neight_ca, t_neigh_ca_dst),
-        std::mem::replace(&mut state.t_a_t, t_a_t_dst),
-        std::mem::replace(&mut state.t_b_t, t_b_t_dst),
-        std::mem::replace(&mut state.t_c_t, t_c_t_dst),
-        std::mem::replace(&mut state.t_center_t, t_center_t_dst),
-        std::mem::replace(&mut state.t_parent, t_parent_dst),
-        std::mem::replace(&mut state.t_deactivated, t_deactivated_dst),
-    ];
-    for buf in &old_bufs {
-        compute_utils::free_rid_on_render_thread(rd, buf.rid);
-    }
-
-    compute_utils::free_rid_on_render_thread(rd, active_prefix_buf.rid);
-    compute_utils::free_rid_on_render_thread(rd, n_tris_total_buf.rid);
-    compute_utils::free_rid_on_render_thread(rd, active_count_buf.rid);
-
-    state.n_tris = active_count;
-    state.n_deactivated_tris = 0;
-
-    // --- Phase B: Compact Vertices ---
-    let vert_active_mask_buf = compute_utils::create_empty_storage_buffer(
-        rd,
-        std::mem::size_of::<i32>() as u32 * state.n_verts,
-    );
-    compute_utils::buffer_clear_on_render_thread(rd, vert_active_mask_buf.rid, 0, vert_active_mask_buf.filled_size);
-
-    let n_tris_uniform = compute_utils::create_uniform_buffer(rd, &state.n_tris);
-    let n_verts_uniform = compute_utils::create_uniform_buffer(rd, &state.n_verts);
-
-    let mark_buffers: Vec<&BufferInfo> = vec![
-        &state.t_abc,            // 0
-        &state.t_deactivated,    // 1
-        &vert_active_mask_buf,   // 2
-        &n_tris_uniform,         // 3
-        &n_verts_uniform,        // 4
-    ];
-
-    compute_utils::dispatch_shader(rd, MARK_ACTIVE_VERTS_SHADER, &mark_buffers, state.n_tris);
-
-    compute_utils::free_rid_on_render_thread(rd, n_tris_uniform.rid);
-    compute_utils::free_rid_on_render_thread(rd, n_verts_uniform.rid);
-
-    let mut vert_mask: Vec<i32> = compute_utils::convert_buffer_to_vec(rd, &vert_active_mask_buf);
-    compute_utils::sum_array_in_place(&mut vert_mask, false);
-
-    let active_verts_count = if vert_mask.is_empty() {
-        0u32
-    } else {
-        vert_mask[vert_mask.len() - 1] as u32
-    };
-
-    if active_verts_count > 0 && active_verts_count != state.n_verts {
-        // Pad prefix array to at least 4 elements (GPU alignment)
-        while vert_mask.len() < 4 {
-            vert_mask.push(*vert_mask.last().unwrap_or(&0));
+        if active_count == 0 || active_count == state.n_tris {
+            return 0;
         }
 
-        let vert_prefix_buf = compute_utils::create_storage_buffer(rd, &vert_mask);
+        let active_prefix_buf = compute_utils::create_storage_buffer(rd, &deactivated);
 
-        let v_pos_dst = compute_utils::create_empty_storage_buffer(
-            rd,
-            4 * std::mem::size_of::<f32>() as u32 * active_verts_count,
-        );
-        let v_update_mask_dst = compute_utils::create_empty_storage_buffer(
-            rd,
-            std::mem::size_of::<i32>() as u32 * active_verts_count,
-        );
+        // Create 15 destination buffers for compacted triangle data
+        let tri_elem_size = std::mem::size_of::<i32>() as u32;
+        let dst_byte_size = tri_elem_size * active_count;
+        let t_abc_dst =
+            compute_utils::create_empty_storage_buffer(rd, 4 * tri_elem_size * active_count);
+        let t_divided_dst = compute_utils::create_empty_storage_buffer(rd, dst_byte_size);
+        let t_lv_dst = compute_utils::create_empty_storage_buffer(rd, dst_byte_size);
+        let t_to_div_dst = compute_utils::create_empty_storage_buffer(rd, dst_byte_size);
+        let t_to_merge_dst = compute_utils::create_empty_storage_buffer(rd, dst_byte_size);
+        let t_ico_idx_dst = compute_utils::create_empty_storage_buffer(rd, dst_byte_size);
+        let t_neigh_ab_dst = compute_utils::create_empty_storage_buffer(rd, dst_byte_size);
+        let t_neigh_bc_dst = compute_utils::create_empty_storage_buffer(rd, dst_byte_size);
+        let t_neigh_ca_dst = compute_utils::create_empty_storage_buffer(rd, dst_byte_size);
+        let t_a_t_dst = compute_utils::create_empty_storage_buffer(rd, dst_byte_size);
+        let t_b_t_dst = compute_utils::create_empty_storage_buffer(rd, dst_byte_size);
+        let t_c_t_dst = compute_utils::create_empty_storage_buffer(rd, dst_byte_size);
+        let t_center_t_dst = compute_utils::create_empty_storage_buffer(rd, dst_byte_size);
+        let t_parent_dst = compute_utils::create_empty_storage_buffer(rd, dst_byte_size);
+        let t_deactivated_dst = compute_utils::create_empty_storage_buffer(rd, dst_byte_size);
 
-        let n_verts_total_buf = compute_utils::create_uniform_buffer(rd, &state.n_verts);
-        let active_verts_count_buf = compute_utils::create_uniform_buffer(rd, &active_verts_count);
+        let active_count_buf = compute_utils::create_uniform_buffer(rd, &active_count);
 
-        let compact_vert_buffers: Vec<&BufferInfo> = vec![
-            &vert_active_mask_buf,    // 0
-            &vert_prefix_buf,         // 1
-            &state.v_pos,             // 2
-            &state.v_update_mask,     // 3
-            &v_pos_dst,               // 4
-            &v_update_mask_dst,       // 5
-            &n_verts_total_buf,       // 6
-            &active_verts_count_buf,  // 7
+        let buffers: Vec<&BufferInfo> = vec![
+            &state.t_deactivated,    // 0
+            &active_prefix_buf,      // 1
+            &state.t_abc,            // 2
+            &state.t_divided,        // 3
+            &state.t_lv,             // 4
+            &state.t_to_divide_mask, // 5
+            &state.t_to_merge_mask,  // 6
+            &state.t_ico_idx,        // 7
+            &state.t_neight_ab,      // 8
+            &state.t_neight_bc,      // 9
+            &state.t_neight_ca,      // 10
+            &state.t_a_t,            // 11
+            &state.t_b_t,            // 12
+            &state.t_c_t,            // 13
+            &state.t_center_t,       // 14
+            &state.t_parent,         // 15
+            &t_abc_dst,              // 16
+            &t_divided_dst,          // 17
+            &t_lv_dst,               // 18
+            &t_to_div_dst,           // 19
+            &t_to_merge_dst,         // 20
+            &t_ico_idx_dst,          // 21
+            &t_neigh_ab_dst,         // 22
+            &t_neigh_bc_dst,         // 23
+            &t_neigh_ca_dst,         // 24
+            &t_a_t_dst,              // 25
+            &t_b_t_dst,              // 26
+            &t_c_t_dst,              // 27
+            &t_center_t_dst,         // 28
+            &t_parent_dst,           // 29
+            &t_deactivated_dst,      // 30
+            &state.u_n_tris,         // 31
+            &active_count_buf,       // 32
         ];
 
-        compute_utils::dispatch_shader(
+        self.compact_tris.dispatch(rd, &buffers, state.n_tris);
+
+        // Swap old buffers with compacted ones, free old
+        let old_bufs = [
+            std::mem::replace(&mut state.t_abc, t_abc_dst),
+            std::mem::replace(&mut state.t_divided, t_divided_dst),
+            std::mem::replace(&mut state.t_lv, t_lv_dst),
+            std::mem::replace(&mut state.t_to_divide_mask, t_to_div_dst),
+            std::mem::replace(&mut state.t_to_merge_mask, t_to_merge_dst),
+            std::mem::replace(&mut state.t_ico_idx, t_ico_idx_dst),
+            std::mem::replace(&mut state.t_neight_ab, t_neigh_ab_dst),
+            std::mem::replace(&mut state.t_neight_bc, t_neigh_bc_dst),
+            std::mem::replace(&mut state.t_neight_ca, t_neigh_ca_dst),
+            std::mem::replace(&mut state.t_a_t, t_a_t_dst),
+            std::mem::replace(&mut state.t_b_t, t_b_t_dst),
+            std::mem::replace(&mut state.t_c_t, t_c_t_dst),
+            std::mem::replace(&mut state.t_center_t, t_center_t_dst),
+            std::mem::replace(&mut state.t_parent, t_parent_dst),
+            std::mem::replace(&mut state.t_deactivated, t_deactivated_dst),
+        ];
+        for buf in &old_bufs {
+            compute_utils::free_rid_on_render_thread(rd, buf.rid);
+        }
+
+        compute_utils::free_rid_on_render_thread(rd, active_prefix_buf.rid);
+        compute_utils::free_rid_on_render_thread(rd, active_count_buf.rid);
+
+        state.n_tris = active_count;
+        state.n_deactivated_tris = 0;
+
+        // Sync n_tris uniform buffer after update (needed by Phase B)
+        state.sync_n_tris_buffer(rd);
+
+        // --- Phase B: Compact Vertices ---
+        let vert_active_mask_buf = compute_utils::create_empty_storage_buffer(
             rd,
-            COMPACT_VERTS_SHADER,
-            &compact_vert_buffers,
-            state.n_verts,
+            std::mem::size_of::<i32>() as u32 * state.n_verts,
+        );
+        compute_utils::buffer_clear_on_render_thread(
+            rd,
+            vert_active_mask_buf.rid,
+            0,
+            vert_active_mask_buf.filled_size,
         );
 
-        // Swap vertex buffers
-        let old_v_pos = std::mem::replace(&mut state.v_pos, v_pos_dst);
-        let old_v_mask = std::mem::replace(&mut state.v_update_mask, v_update_mask_dst);
-        compute_utils::free_rid_on_render_thread(rd, old_v_pos.rid);
-        compute_utils::free_rid_on_render_thread(rd, old_v_mask.rid);
-
-        state.n_verts = active_verts_count;
-
-        // --- Phase C: Remap Triangle Vertex Indices ---
-        let t_abc_remapped = compute_utils::create_empty_storage_buffer(
-            rd,
-            4 * std::mem::size_of::<i32>() as u32 * state.n_tris,
-        );
-
-        let n_tris_remap_buf = compute_utils::create_uniform_buffer(rd, &state.n_tris);
-        let active_verts_remap_buf =
-            compute_utils::create_uniform_buffer(rd, &active_verts_count);
-
-        let remap_buffers: Vec<&BufferInfo> = vec![
-            &state.t_abc,              // 0
-            &vert_prefix_buf,          // 1
-            &t_abc_remapped,           // 2
-            &n_tris_remap_buf,         // 3
-            &active_verts_remap_buf,   // 4
+        let mark_buffers: Vec<&BufferInfo> = vec![
+            &state.t_abc,          // 0
+            &state.t_deactivated,  // 1
+            &vert_active_mask_buf, // 2
+            &state.u_n_tris,       // 3
+            &state.u_n_verts,      // 4
         ];
 
-        compute_utils::dispatch_shader(
-            rd,
-            REMAP_TRI_VERTS_SHADER,
-            &remap_buffers,
-            state.n_tris,
-        );
+        self.mark_active_verts
+            .dispatch(rd, &mark_buffers, state.n_tris);
 
-        let old_t_abc = std::mem::replace(&mut state.t_abc, t_abc_remapped);
-        compute_utils::free_rid_on_render_thread(rd, old_t_abc.rid);
+        let mut vert_mask: Vec<i32> =
+            compute_utils::convert_buffer_to_vec(rd, &vert_active_mask_buf);
+        compute_utils::sum_array_in_place(&mut vert_mask, false);
 
-        compute_utils::free_rid_on_render_thread(rd, n_tris_remap_buf.rid);
-        compute_utils::free_rid_on_render_thread(rd, active_verts_remap_buf.rid);
-        compute_utils::free_rid_on_render_thread(rd, vert_prefix_buf.rid);
-        compute_utils::free_rid_on_render_thread(rd, n_verts_total_buf.rid);
-        compute_utils::free_rid_on_render_thread(rd, active_verts_count_buf.rid);
+        let active_verts_count = if vert_mask.is_empty() {
+            0u32
+        } else {
+            vert_mask[vert_mask.len() - 1] as u32
+        };
+
+        if active_verts_count > 0 && active_verts_count != state.n_verts {
+            // Pad prefix array to at least 4 elements (GPU alignment)
+            while vert_mask.len() < 4 {
+                vert_mask.push(*vert_mask.last().unwrap_or(&0));
+            }
+
+            let vert_prefix_buf = compute_utils::create_storage_buffer(rd, &vert_mask);
+
+            let v_pos_dst = compute_utils::create_empty_storage_buffer(
+                rd,
+                4 * std::mem::size_of::<f32>() as u32 * active_verts_count,
+            );
+            let v_update_mask_dst = compute_utils::create_empty_storage_buffer(
+                rd,
+                std::mem::size_of::<i32>() as u32 * active_verts_count,
+            );
+
+            let active_verts_count_buf =
+                compute_utils::create_uniform_buffer(rd, &active_verts_count);
+
+            let compact_vert_buffers: Vec<&BufferInfo> = vec![
+                &vert_active_mask_buf,   // 0
+                &vert_prefix_buf,        // 1
+                &state.v_pos,            // 2
+                &state.v_update_mask,    // 3
+                &v_pos_dst,              // 4
+                &v_update_mask_dst,      // 5
+                &state.u_n_verts,        // 6
+                &active_verts_count_buf, // 7
+            ];
+
+            self.compact_verts
+                .dispatch(rd, &compact_vert_buffers, state.n_verts);
+
+            // Swap vertex buffers
+            let old_v_pos = std::mem::replace(&mut state.v_pos, v_pos_dst);
+            let old_v_mask = std::mem::replace(&mut state.v_update_mask, v_update_mask_dst);
+            compute_utils::free_rid_on_render_thread(rd, old_v_pos.rid);
+            compute_utils::free_rid_on_render_thread(rd, old_v_mask.rid);
+
+            state.n_verts = active_verts_count;
+
+            // Sync n_verts uniform buffer after update (needed by Phase C)
+            state.sync_n_verts_buffer(rd);
+
+            // --- Phase C: Remap Triangle Vertex Indices ---
+            let t_abc_remapped = compute_utils::create_empty_storage_buffer(
+                rd,
+                4 * std::mem::size_of::<i32>() as u32 * state.n_tris,
+            );
+
+            let active_verts_remap_buf =
+                compute_utils::create_uniform_buffer(rd, &active_verts_count);
+
+            let remap_buffers: Vec<&BufferInfo> = vec![
+                &state.t_abc,            // 0
+                &vert_prefix_buf,        // 1
+                &t_abc_remapped,         // 2
+                &state.u_n_tris,         // 3
+                &active_verts_remap_buf, // 4
+            ];
+
+            self.remap_tri_verts
+                .dispatch(rd, &remap_buffers, state.n_tris);
+
+            let old_t_abc = std::mem::replace(&mut state.t_abc, t_abc_remapped);
+            compute_utils::free_rid_on_render_thread(rd, old_t_abc.rid);
+
+            compute_utils::free_rid_on_render_thread(rd, active_verts_remap_buf.rid);
+            compute_utils::free_rid_on_render_thread(rd, vert_prefix_buf.rid);
+            compute_utils::free_rid_on_render_thread(rd, active_verts_count_buf.rid);
+        }
+
+        compute_utils::free_rid_on_render_thread(rd, vert_active_mask_buf.rid);
+
+        active_count
     }
-
-    compute_utils::free_rid_on_render_thread(rd, vert_active_mask_buf.rid);
-
-    active_count
 }
 
 #[cfg(test)]

--- a/rust/src/algo/compact_buffers.rs
+++ b/rust/src/algo/compact_buffers.rs
@@ -1,0 +1,294 @@
+use godot::classes::RenderingDevice;
+
+use crate::buffer_info::BufferInfo;
+use crate::compute_utils;
+use crate::state::CesState;
+
+const COMPACT_TRIS_SHADER: &str = "res://addons/celestial_sim_rust/shaders/CompactTris.slang";
+const MARK_ACTIVE_VERTS_SHADER: &str =
+    "res://addons/celestial_sim_rust/shaders/MarkActiveVertices.slang";
+const COMPACT_VERTS_SHADER: &str =
+    "res://addons/celestial_sim_rust/shaders/CompactVertices.slang";
+const REMAP_TRI_VERTS_SHADER: &str =
+    "res://addons/celestial_sim_rust/shaders/RemapTriangleVertices.slang";
+
+/// Compacts deactivated triangles and unused vertices from the mesh buffers.
+/// Mirrors C# `CesCompactBuffers.Compact()`.
+///
+/// Returns 0 if nothing was compacted, otherwise returns the count of compacted items.
+pub fn compact(rd: &mut RenderingDevice, state: &mut CesState) -> u32 {
+    // --- Phase A: Compact Triangles ---
+    let mut deactivated: Vec<i32> = compute_utils::convert_buffer_to_vec(rd, &state.t_deactivated);
+
+    // Prefix sum inverted: count active (non-deactivated) triangles
+    compute_utils::sum_array_in_place(&mut deactivated, true);
+
+    let active_count = if deactivated.is_empty() {
+        0u32
+    } else {
+        deactivated[deactivated.len() - 1] as u32
+    };
+
+    if active_count == 0 || active_count == state.n_tris {
+        return 0;
+    }
+
+    let active_prefix_buf = compute_utils::create_storage_buffer(rd, &deactivated);
+
+    // Create 15 destination buffers for compacted triangle data
+    let tri_elem_size = std::mem::size_of::<i32>() as u32;
+    let dst_byte_size = tri_elem_size * active_count;
+    let t_abc_dst = compute_utils::create_empty_storage_buffer(rd, 4 * tri_elem_size * active_count);
+    let t_divided_dst = compute_utils::create_empty_storage_buffer(rd, dst_byte_size);
+    let t_lv_dst = compute_utils::create_empty_storage_buffer(rd, dst_byte_size);
+    let t_to_div_dst = compute_utils::create_empty_storage_buffer(rd, dst_byte_size);
+    let t_to_merge_dst = compute_utils::create_empty_storage_buffer(rd, dst_byte_size);
+    let t_ico_idx_dst = compute_utils::create_empty_storage_buffer(rd, dst_byte_size);
+    let t_neigh_ab_dst = compute_utils::create_empty_storage_buffer(rd, dst_byte_size);
+    let t_neigh_bc_dst = compute_utils::create_empty_storage_buffer(rd, dst_byte_size);
+    let t_neigh_ca_dst = compute_utils::create_empty_storage_buffer(rd, dst_byte_size);
+    let t_a_t_dst = compute_utils::create_empty_storage_buffer(rd, dst_byte_size);
+    let t_b_t_dst = compute_utils::create_empty_storage_buffer(rd, dst_byte_size);
+    let t_c_t_dst = compute_utils::create_empty_storage_buffer(rd, dst_byte_size);
+    let t_center_t_dst = compute_utils::create_empty_storage_buffer(rd, dst_byte_size);
+    let t_parent_dst = compute_utils::create_empty_storage_buffer(rd, dst_byte_size);
+    let t_deactivated_dst = compute_utils::create_empty_storage_buffer(rd, dst_byte_size);
+
+    let n_tris_total_buf = compute_utils::create_uniform_buffer(rd, &state.n_tris);
+    let active_count_buf = compute_utils::create_uniform_buffer(rd, &active_count);
+
+    let buffers: Vec<&BufferInfo> = vec![
+        &state.t_deactivated,   // 0
+        &active_prefix_buf,     // 1
+        &state.t_abc,           // 2
+        &state.t_divided,       // 3
+        &state.t_lv,            // 4
+        &state.t_to_divide_mask, // 5
+        &state.t_to_merge_mask, // 6
+        &state.t_ico_idx,       // 7
+        &state.t_neight_ab,     // 8
+        &state.t_neight_bc,     // 9
+        &state.t_neight_ca,     // 10
+        &state.t_a_t,           // 11
+        &state.t_b_t,           // 12
+        &state.t_c_t,           // 13
+        &state.t_center_t,      // 14
+        &state.t_parent,        // 15
+        &t_abc_dst,             // 16
+        &t_divided_dst,         // 17
+        &t_lv_dst,              // 18
+        &t_to_div_dst,          // 19
+        &t_to_merge_dst,        // 20
+        &t_ico_idx_dst,         // 21
+        &t_neigh_ab_dst,        // 22
+        &t_neigh_bc_dst,        // 23
+        &t_neigh_ca_dst,        // 24
+        &t_a_t_dst,             // 25
+        &t_b_t_dst,             // 26
+        &t_c_t_dst,             // 27
+        &t_center_t_dst,        // 28
+        &t_parent_dst,          // 29
+        &t_deactivated_dst,     // 30
+        &n_tris_total_buf,      // 31
+        &active_count_buf,      // 32
+    ];
+
+    compute_utils::dispatch_shader(rd, COMPACT_TRIS_SHADER, &buffers, state.n_tris);
+
+    // Swap old buffers with compacted ones, free old
+    let old_bufs = [
+        std::mem::replace(&mut state.t_abc, t_abc_dst),
+        std::mem::replace(&mut state.t_divided, t_divided_dst),
+        std::mem::replace(&mut state.t_lv, t_lv_dst),
+        std::mem::replace(&mut state.t_to_divide_mask, t_to_div_dst),
+        std::mem::replace(&mut state.t_to_merge_mask, t_to_merge_dst),
+        std::mem::replace(&mut state.t_ico_idx, t_ico_idx_dst),
+        std::mem::replace(&mut state.t_neight_ab, t_neigh_ab_dst),
+        std::mem::replace(&mut state.t_neight_bc, t_neigh_bc_dst),
+        std::mem::replace(&mut state.t_neight_ca, t_neigh_ca_dst),
+        std::mem::replace(&mut state.t_a_t, t_a_t_dst),
+        std::mem::replace(&mut state.t_b_t, t_b_t_dst),
+        std::mem::replace(&mut state.t_c_t, t_c_t_dst),
+        std::mem::replace(&mut state.t_center_t, t_center_t_dst),
+        std::mem::replace(&mut state.t_parent, t_parent_dst),
+        std::mem::replace(&mut state.t_deactivated, t_deactivated_dst),
+    ];
+    for buf in &old_bufs {
+        rd.free_rid(buf.rid);
+    }
+
+    rd.free_rid(active_prefix_buf.rid);
+    rd.free_rid(n_tris_total_buf.rid);
+    rd.free_rid(active_count_buf.rid);
+
+    state.n_tris = active_count;
+    state.n_deactivated_tris = 0;
+
+    // --- Phase B: Compact Vertices ---
+    let vert_active_mask_buf = compute_utils::create_empty_storage_buffer(
+        rd,
+        std::mem::size_of::<i32>() as u32 * state.n_verts,
+    );
+    rd.buffer_clear(vert_active_mask_buf.rid, 0, vert_active_mask_buf.filled_size);
+
+    let n_tris_uniform = compute_utils::create_uniform_buffer(rd, &state.n_tris);
+    let n_verts_uniform = compute_utils::create_uniform_buffer(rd, &state.n_verts);
+
+    let mark_buffers: Vec<&BufferInfo> = vec![
+        &state.t_abc,            // 0
+        &state.t_deactivated,    // 1
+        &vert_active_mask_buf,   // 2
+        &n_tris_uniform,         // 3
+        &n_verts_uniform,        // 4
+    ];
+
+    compute_utils::dispatch_shader(rd, MARK_ACTIVE_VERTS_SHADER, &mark_buffers, state.n_tris);
+
+    rd.free_rid(n_tris_uniform.rid);
+    rd.free_rid(n_verts_uniform.rid);
+
+    let mut vert_mask: Vec<i32> = compute_utils::convert_buffer_to_vec(rd, &vert_active_mask_buf);
+    compute_utils::sum_array_in_place(&mut vert_mask, false);
+
+    let active_verts_count = if vert_mask.is_empty() {
+        0u32
+    } else {
+        vert_mask[vert_mask.len() - 1] as u32
+    };
+
+    if active_verts_count > 0 && active_verts_count != state.n_verts {
+        // Pad prefix array to at least 4 elements (GPU alignment)
+        while vert_mask.len() < 4 {
+            vert_mask.push(*vert_mask.last().unwrap_or(&0));
+        }
+
+        let vert_prefix_buf = compute_utils::create_storage_buffer(rd, &vert_mask);
+
+        let v_pos_dst = compute_utils::create_empty_storage_buffer(
+            rd,
+            4 * std::mem::size_of::<f32>() as u32 * active_verts_count,
+        );
+        let v_update_mask_dst = compute_utils::create_empty_storage_buffer(
+            rd,
+            std::mem::size_of::<i32>() as u32 * active_verts_count,
+        );
+
+        let n_verts_total_buf = compute_utils::create_uniform_buffer(rd, &state.n_verts);
+        let active_verts_count_buf = compute_utils::create_uniform_buffer(rd, &active_verts_count);
+
+        let compact_vert_buffers: Vec<&BufferInfo> = vec![
+            &vert_active_mask_buf,    // 0
+            &vert_prefix_buf,         // 1
+            &state.v_pos,             // 2
+            &state.v_update_mask,     // 3
+            &v_pos_dst,               // 4
+            &v_update_mask_dst,       // 5
+            &n_verts_total_buf,       // 6
+            &active_verts_count_buf,  // 7
+        ];
+
+        compute_utils::dispatch_shader(
+            rd,
+            COMPACT_VERTS_SHADER,
+            &compact_vert_buffers,
+            state.n_verts,
+        );
+
+        // Swap vertex buffers
+        let old_v_pos = std::mem::replace(&mut state.v_pos, v_pos_dst);
+        let old_v_mask = std::mem::replace(&mut state.v_update_mask, v_update_mask_dst);
+        rd.free_rid(old_v_pos.rid);
+        rd.free_rid(old_v_mask.rid);
+
+        state.n_verts = active_verts_count;
+
+        // --- Phase C: Remap Triangle Vertex Indices ---
+        let t_abc_remapped = compute_utils::create_empty_storage_buffer(
+            rd,
+            4 * std::mem::size_of::<i32>() as u32 * state.n_tris,
+        );
+
+        let n_tris_remap_buf = compute_utils::create_uniform_buffer(rd, &state.n_tris);
+        let active_verts_remap_buf =
+            compute_utils::create_uniform_buffer(rd, &active_verts_count);
+
+        let remap_buffers: Vec<&BufferInfo> = vec![
+            &state.t_abc,              // 0
+            &vert_prefix_buf,          // 1
+            &t_abc_remapped,           // 2
+            &n_tris_remap_buf,         // 3
+            &active_verts_remap_buf,   // 4
+        ];
+
+        compute_utils::dispatch_shader(
+            rd,
+            REMAP_TRI_VERTS_SHADER,
+            &remap_buffers,
+            state.n_tris,
+        );
+
+        let old_t_abc = std::mem::replace(&mut state.t_abc, t_abc_remapped);
+        rd.free_rid(old_t_abc.rid);
+
+        rd.free_rid(n_tris_remap_buf.rid);
+        rd.free_rid(active_verts_remap_buf.rid);
+        rd.free_rid(vert_prefix_buf.rid);
+        rd.free_rid(n_verts_total_buf.rid);
+        rd.free_rid(active_verts_count_buf.rid);
+    }
+
+    rd.free_rid(vert_active_mask_buf.rid);
+
+    active_count
+}
+
+#[cfg(test)]
+mod tests {
+    use crate::compute_utils::sum_array_in_place;
+
+    #[test]
+    fn test_prefix_sum_for_compaction() {
+        // invert=true: count where value is 0 (active triangles)
+        // [0,1,0,0,1] → active at indices 0,2,3 → prefix = [1,1,2,3,3]
+        let mut arr = vec![0i32, 1, 0, 0, 1];
+        sum_array_in_place(&mut arr, true);
+        assert_eq!(arr, vec![1, 1, 2, 3, 3]);
+    }
+
+    #[test]
+    fn test_prefix_sum_active_count() {
+        // active_count is the last element of the inverted prefix sum
+        let mut arr = vec![0i32, 1, 0, 0, 1];
+        sum_array_in_place(&mut arr, true);
+        let active_count = *arr.last().unwrap() as u32;
+        assert_eq!(active_count, 3);
+    }
+
+    #[test]
+    fn test_no_compact_when_all_active() {
+        // When no triangles are deactivated, active_count == n_tris → return 0
+        let mut arr = vec![0i32, 0, 0, 0, 0];
+        sum_array_in_place(&mut arr, true);
+        let active_count = *arr.last().unwrap() as u32;
+        let n_tris: u32 = 5;
+        // The function would return 0 because active_count == n_tris
+        assert_eq!(active_count, n_tris);
+    }
+
+    #[test]
+    fn test_prefix_sum_all_deactivated() {
+        // All deactivated: active_count == 0 → return 0
+        let mut arr = vec![1i32, 1, 1, 1];
+        sum_array_in_place(&mut arr, true);
+        let active_count = *arr.last().unwrap() as u32;
+        assert_eq!(active_count, 0);
+    }
+
+    #[test]
+    fn test_prefix_sum_vertex_compaction() {
+        // Non-inverted prefix sum for vertex mask
+        let mut arr = vec![1i32, 0, 1, 1, 0];
+        sum_array_in_place(&mut arr, false);
+        assert_eq!(arr, vec![1, 1, 2, 3, 3]);
+    }
+}

--- a/rust/src/algo/div_lod.rs
+++ b/rust/src/algo/div_lod.rs
@@ -1,4 +1,5 @@
 use godot::classes::RenderingDevice;
+use godot::obj::Gd;
 
 use crate::buffer_info::BufferInfo;
 use crate::compute_utils;
@@ -19,7 +20,7 @@ fn sort_pair(a: i32, b: i32) -> [i32; 2] {
 ///
 /// Returns the modified `tabc` array (with child triangles appended) and the
 /// number of new vertices created.
-fn compute_new_indices(rd: &mut RenderingDevice, state: &CesState) -> (Vec<Triangle>, u32) {
+fn compute_new_indices(rd: &mut Gd<RenderingDevice>, state: &CesState) -> (Vec<Triangle>, u32) {
     let to_div_mask = state.get_t_to_divide_mask(rd);
     let mut tabc = state.get_t_abc(rd);
     let start_vindex = state.n_verts as i32;
@@ -142,7 +143,7 @@ fn compute_new_indices(rd: &mut RenderingDevice, state: &CesState) -> (Vec<Trian
 /// Performs triangle subdivision. Mirrors C# `CesDivLOD.MakeDiv()`.
 ///
 /// Returns the number of triangles added (0 if nothing to divide).
-pub fn make_div(rd: &mut RenderingDevice, state: &mut CesState, precise_normals: bool) -> u32 {
+pub fn make_div(rd: &mut Gd<RenderingDevice>, state: &mut CesState, precise_normals: bool) -> u32 {
     let remove_repeated_verts: u32 = if precise_normals { 1 } else { 0 };
 
     let to_div_mask = state.get_t_to_divide_mask(rd);
@@ -171,7 +172,7 @@ pub fn make_div(rd: &mut RenderingDevice, state: &mut CesState, precise_normals:
         let (new_tabc, deduped_verts) = compute_new_indices(rd, state);
         n_verts_added = deduped_verts;
         // Replace t_abc buffer with the CPU-computed one
-        rd.free_rid(state.t_abc.rid);
+        compute_utils::free_rid_on_render_thread(rd, state.t_abc.rid);
         state.t_abc = compute_utils::create_storage_buffer(rd, &new_tabc);
     }
 
@@ -237,12 +238,12 @@ pub fn make_div(rd: &mut RenderingDevice, state: &mut CesState, precise_normals:
     compute_utils::dispatch_shader(rd, SHADER_PATH, &buffers, n_tris_to_div);
 
     // Free temporary buffers
-    rd.free_rid(indices_to_div_buf.rid);
-    rd.free_rid(old_n_tris_buf.rid);
-    rd.free_rid(old_n_verts_buf.rid);
-    rd.free_rid(n_tris_to_div_buf.rid);
-    rd.free_rid(n_verts_added_buf.rid);
-    rd.free_rid(remove_repeated_buf.rid);
+    compute_utils::free_rid_on_render_thread(rd, indices_to_div_buf.rid);
+    compute_utils::free_rid_on_render_thread(rd, old_n_tris_buf.rid);
+    compute_utils::free_rid_on_render_thread(rd, old_n_verts_buf.rid);
+    compute_utils::free_rid_on_render_thread(rd, n_tris_to_div_buf.rid);
+    compute_utils::free_rid_on_render_thread(rd, n_verts_added_buf.rid);
+    compute_utils::free_rid_on_render_thread(rd, remove_repeated_buf.rid);
 
     n_tris_added
 }

--- a/rust/src/algo/div_lod.rs
+++ b/rust/src/algo/div_lod.rs
@@ -3,13 +3,30 @@ use godot::obj::Gd;
 
 use crate::buffer_info::BufferInfo;
 use crate::compute_utils;
+use crate::compute_utils::ComputePipeline;
 use crate::state::{CesState, Triangle};
 
 const SHADER_PATH: &str = "res://addons/celestial_sim_rust/shaders/DivideLOD.slang";
 
+pub struct DivShader {
+    pipeline: ComputePipeline,
+}
+
+impl DivShader {
+    pub fn new(rd: &mut Gd<RenderingDevice>) -> Self {
+        Self {
+            pipeline: ComputePipeline::new(rd, SHADER_PATH),
+        }
+    }
+}
+
 /// Returns `[min(a,b), max(a,b)]`.
 fn sort_pair(a: i32, b: i32) -> [i32; 2] {
-    if a < b { [a, b] } else { [b, a] }
+    if a < b {
+        [a, b]
+    } else {
+        [b, a]
+    }
 }
 
 /// CPU-side edge deduplication for precise normals mode.
@@ -118,17 +135,42 @@ fn compute_new_indices(rd: &mut Gd<RenderingDevice>, state: &CesState) -> (Vec<T
 
         // Ensure tabc is large enough
         while tabc.len() <= base + 3 {
-            tabc.push(Triangle { a: 0, b: 0, c: 0, w: 0 });
+            tabc.push(Triangle {
+                a: 0,
+                b: 0,
+                c: 0,
+                w: 0,
+            });
         }
 
         // child 0: (a, midAB, midCA)
-        tabc[base] = Triangle { a, b: new_vertex_ab, c: new_vertex_ca, w: 0 };
+        tabc[base] = Triangle {
+            a,
+            b: new_vertex_ab,
+            c: new_vertex_ca,
+            w: 0,
+        };
         // child 1: (midAB, b, midBC)
-        tabc[base + 1] = Triangle { a: new_vertex_ab, b, c: new_vertex_bc, w: 0 };
+        tabc[base + 1] = Triangle {
+            a: new_vertex_ab,
+            b,
+            c: new_vertex_bc,
+            w: 0,
+        };
         // child 2: (midCA, midBC, c)
-        tabc[base + 2] = Triangle { a: new_vertex_ca, b: new_vertex_bc, c, w: 0 };
+        tabc[base + 2] = Triangle {
+            a: new_vertex_ca,
+            b: new_vertex_bc,
+            c,
+            w: 0,
+        };
         // child 3: (midBC, midCA, midAB) — center triangle
-        tabc[base + 3] = Triangle { a: new_vertex_bc, b: new_vertex_ca, c: new_vertex_ab, w: 0 };
+        tabc[base + 3] = Triangle {
+            a: new_vertex_bc,
+            b: new_vertex_ca,
+            c: new_vertex_ab,
+            w: 0,
+        };
 
         // Store midpoint indices
         added_idxs[i] = [new_vertex_ab, new_vertex_bc, new_vertex_ca];
@@ -140,112 +182,125 @@ fn compute_new_indices(rd: &mut Gd<RenderingDevice>, state: &CesState) -> (Vec<T
     (tabc, num_new_verts)
 }
 
-/// Performs triangle subdivision. Mirrors C# `CesDivLOD.MakeDiv()`.
-///
-/// Returns the number of triangles added (0 if nothing to divide).
-pub fn make_div(rd: &mut Gd<RenderingDevice>, state: &mut CesState, precise_normals: bool) -> u32 {
-    let remove_repeated_verts: u32 = if precise_normals { 1 } else { 0 };
+impl DivShader {
+    /// Performs triangle subdivision. Mirrors C# `CesDivLOD.MakeDiv()`.
+    ///
+    /// Returns the number of triangles added (0 if nothing to divide).
+    pub fn make_div(
+        &self,
+        rd: &mut Gd<RenderingDevice>,
+        state: &mut CesState,
+        precise_normals: bool,
+    ) -> u32 {
+        let remove_repeated_verts: u32 = if precise_normals { 1 } else { 0 };
 
-    let to_div_mask = state.get_t_to_divide_mask(rd);
-    let divided_mask = state.get_divided_mask(rd);
+        let to_div_mask = state.get_t_to_divide_mask(rd);
+        let divided_mask = state.get_divided_mask(rd);
 
-    let mut indices_to_div: Vec<u32> = Vec::new();
-    for i in 0..to_div_mask.len() {
-        if to_div_mask[i] != 0 && divided_mask[i] == 0 {
-            indices_to_div.push(i as u32);
+        let mut indices_to_div: Vec<u32> = Vec::new();
+        for i in 0..to_div_mask.len() {
+            if to_div_mask[i] != 0 && divided_mask[i] == 0 {
+                indices_to_div.push(i as u32);
+            }
         }
+
+        let n_tris_to_div = indices_to_div.len() as u32;
+        let n_tris_added = 4 * n_tris_to_div;
+        let mut n_verts_added = 3 * n_tris_to_div;
+
+        if n_tris_added == 0 {
+            return 0;
+        }
+
+        let indices_to_div_buf = compute_utils::create_storage_buffer(rd, &indices_to_div);
+
+        // Extend t_abc and optionally compute new indices on CPU
+        state
+            .t_abc
+            .extend_buffer(rd, 4 * std::mem::size_of::<i32>() as u32 * n_tris_added);
+        if precise_normals {
+            let (new_tabc, deduped_verts) = compute_new_indices(rd, state);
+            n_verts_added = deduped_verts;
+            // Replace t_abc buffer with the CPU-computed one
+            compute_utils::free_rid_on_render_thread(rd, state.t_abc.rid);
+            state.t_abc = compute_utils::create_storage_buffer(rd, &new_tabc);
+        }
+
+        // Record old counts before updating
+        let old_n_tris = state.n_tris;
+        let old_n_verts = state.n_verts;
+
+        state.n_tris += n_tris_added;
+        state.n_verts += n_verts_added;
+
+        // Extend vertex buffers
+        state
+            .v_pos
+            .extend_buffer(rd, 4 * std::mem::size_of::<f32>() as u32 * n_verts_added);
+        state
+            .v_update_mask
+            .extend_buffer(rd, std::mem::size_of::<i32>() as u32 * n_verts_added);
+
+        // Extend triangle buffers
+        let tri_extend = std::mem::size_of::<i32>() as u32 * n_tris_added;
+        state.t_lv.extend_buffer(rd, tri_extend);
+        state.t_divided.extend_buffer(rd, tri_extend);
+        state.t_deactivated.extend_buffer(rd, tri_extend);
+        state.t_to_divide_mask.extend_buffer(rd, tri_extend);
+        state.t_to_merge_mask.extend_buffer(rd, tri_extend);
+        state.t_ico_idx.extend_buffer(rd, tri_extend);
+        state.t_neight_ab.extend_buffer(rd, tri_extend);
+        state.t_neight_bc.extend_buffer(rd, tri_extend);
+        state.t_neight_ca.extend_buffer(rd, tri_extend);
+        state.t_a_t.extend_buffer(rd, tri_extend);
+        state.t_b_t.extend_buffer(rd, tri_extend);
+        state.t_c_t.extend_buffer(rd, tri_extend);
+        state.t_center_t.extend_buffer(rd, tri_extend);
+        state.t_parent.extend_buffer(rd, tri_extend);
+
+        // Create uniform buffers for shader parameters
+        let old_n_tris_buf = compute_utils::create_uniform_buffer(rd, &old_n_tris);
+        let old_n_verts_buf = compute_utils::create_uniform_buffer(rd, &old_n_verts);
+        let n_tris_to_div_buf = compute_utils::create_uniform_buffer(rd, &n_tris_to_div);
+        let n_verts_added_buf = compute_utils::create_uniform_buffer(rd, &n_verts_added);
+        let remove_repeated_buf = compute_utils::create_uniform_buffer(rd, &remove_repeated_verts);
+
+        let buffers: Vec<&BufferInfo> = vec![
+            &state.v_pos,            // 0
+            &state.t_abc,            // 1
+            &state.t_divided,        // 2
+            &state.t_to_divide_mask, // 3
+            &old_n_tris_buf,         // 4
+            &old_n_verts_buf,        // 5
+            &n_tris_to_div_buf,      // 6
+            &n_verts_added_buf,      // 7
+            &state.v_update_mask,    // 8
+            &state.t_ico_idx,        // 9
+            &state.t_neight_ab,      // 10
+            &state.t_neight_bc,      // 11
+            &state.t_neight_ca,      // 12
+            &state.t_a_t,            // 13
+            &state.t_b_t,            // 14
+            &state.t_c_t,            // 15
+            &state.t_center_t,       // 16
+            &state.t_parent,         // 17
+            &remove_repeated_buf,    // 18
+            &state.t_lv,             // 19
+            &indices_to_div_buf,     // 20
+        ];
+
+        self.pipeline.dispatch(rd, &buffers, n_tris_to_div);
+
+        // Free temporary buffers
+        compute_utils::free_rid_on_render_thread(rd, indices_to_div_buf.rid);
+        compute_utils::free_rid_on_render_thread(rd, old_n_tris_buf.rid);
+        compute_utils::free_rid_on_render_thread(rd, old_n_verts_buf.rid);
+        compute_utils::free_rid_on_render_thread(rd, n_tris_to_div_buf.rid);
+        compute_utils::free_rid_on_render_thread(rd, n_verts_added_buf.rid);
+        compute_utils::free_rid_on_render_thread(rd, remove_repeated_buf.rid);
+
+        n_tris_added
     }
-
-    let n_tris_to_div = indices_to_div.len() as u32;
-    let n_tris_added = 4 * n_tris_to_div;
-    let mut n_verts_added = 3 * n_tris_to_div;
-
-    if n_tris_added == 0 {
-        return 0;
-    }
-
-    let indices_to_div_buf = compute_utils::create_storage_buffer(rd, &indices_to_div);
-
-    // Extend t_abc and optionally compute new indices on CPU
-    state.t_abc.extend_buffer(rd, 4 * std::mem::size_of::<i32>() as u32 * n_tris_added);
-    if precise_normals {
-        let (new_tabc, deduped_verts) = compute_new_indices(rd, state);
-        n_verts_added = deduped_verts;
-        // Replace t_abc buffer with the CPU-computed one
-        compute_utils::free_rid_on_render_thread(rd, state.t_abc.rid);
-        state.t_abc = compute_utils::create_storage_buffer(rd, &new_tabc);
-    }
-
-    // Record old counts before updating
-    let old_n_tris = state.n_tris;
-    let old_n_verts = state.n_verts;
-
-    state.n_tris += n_tris_added;
-    state.n_verts += n_verts_added;
-
-    // Extend vertex buffers
-    state.v_pos.extend_buffer(rd, 4 * std::mem::size_of::<f32>() as u32 * n_verts_added);
-    state.v_update_mask.extend_buffer(rd, std::mem::size_of::<i32>() as u32 * n_verts_added);
-
-    // Extend triangle buffers
-    let tri_extend = std::mem::size_of::<i32>() as u32 * n_tris_added;
-    state.t_lv.extend_buffer(rd, tri_extend);
-    state.t_divided.extend_buffer(rd, tri_extend);
-    state.t_deactivated.extend_buffer(rd, tri_extend);
-    state.t_to_divide_mask.extend_buffer(rd, tri_extend);
-    state.t_to_merge_mask.extend_buffer(rd, tri_extend);
-    state.t_ico_idx.extend_buffer(rd, tri_extend);
-    state.t_neight_ab.extend_buffer(rd, tri_extend);
-    state.t_neight_bc.extend_buffer(rd, tri_extend);
-    state.t_neight_ca.extend_buffer(rd, tri_extend);
-    state.t_a_t.extend_buffer(rd, tri_extend);
-    state.t_b_t.extend_buffer(rd, tri_extend);
-    state.t_c_t.extend_buffer(rd, tri_extend);
-    state.t_center_t.extend_buffer(rd, tri_extend);
-    state.t_parent.extend_buffer(rd, tri_extend);
-
-    // Create uniform buffers for shader parameters
-    let old_n_tris_buf = compute_utils::create_uniform_buffer(rd, &old_n_tris);
-    let old_n_verts_buf = compute_utils::create_uniform_buffer(rd, &old_n_verts);
-    let n_tris_to_div_buf = compute_utils::create_uniform_buffer(rd, &n_tris_to_div);
-    let n_verts_added_buf = compute_utils::create_uniform_buffer(rd, &n_verts_added);
-    let remove_repeated_buf = compute_utils::create_uniform_buffer(rd, &remove_repeated_verts);
-
-    let buffers: Vec<&BufferInfo> = vec![
-        &state.v_pos,              // 0
-        &state.t_abc,              // 1
-        &state.t_divided,          // 2
-        &state.t_to_divide_mask,   // 3
-        &old_n_tris_buf,           // 4
-        &old_n_verts_buf,          // 5
-        &n_tris_to_div_buf,        // 6
-        &n_verts_added_buf,        // 7
-        &state.v_update_mask,      // 8
-        &state.t_ico_idx,          // 9
-        &state.t_neight_ab,        // 10
-        &state.t_neight_bc,        // 11
-        &state.t_neight_ca,        // 12
-        &state.t_a_t,              // 13
-        &state.t_b_t,              // 14
-        &state.t_c_t,              // 15
-        &state.t_center_t,         // 16
-        &state.t_parent,           // 17
-        &remove_repeated_buf,      // 18
-        &state.t_lv,               // 19
-        &indices_to_div_buf,       // 20
-    ];
-
-    compute_utils::dispatch_shader(rd, SHADER_PATH, &buffers, n_tris_to_div);
-
-    // Free temporary buffers
-    compute_utils::free_rid_on_render_thread(rd, indices_to_div_buf.rid);
-    compute_utils::free_rid_on_render_thread(rd, old_n_tris_buf.rid);
-    compute_utils::free_rid_on_render_thread(rd, old_n_verts_buf.rid);
-    compute_utils::free_rid_on_render_thread(rd, n_tris_to_div_buf.rid);
-    compute_utils::free_rid_on_render_thread(rd, n_verts_added_buf.rid);
-    compute_utils::free_rid_on_render_thread(rd, remove_repeated_buf.rid);
-
-    n_tris_added
 }
 
 #[cfg(test)]
@@ -277,8 +332,18 @@ mod tests {
 
         let to_div_mask = vec![1i32, 1];
         let tabc = vec![
-            Triangle { a: 0, b: 1, c: 2, w: 0 },
-            Triangle { a: 1, b: 3, c: 2, w: 0 },
+            Triangle {
+                a: 0,
+                b: 1,
+                c: 2,
+                w: 0,
+            },
+            Triangle {
+                a: 1,
+                b: 3,
+                c: 2,
+                w: 0,
+            },
         ];
         let n_verts: u32 = 4;
         let n_tris: u32 = 2;
@@ -318,9 +383,13 @@ mod tests {
                     let nab = sort_pair(tabc[ni].a, tabc[ni].b);
                     let nbc = sort_pair(tabc[ni].b, tabc[ni].c);
                     let ab = sort_pair(a, b);
-                    if nab == ab { added_idxs[ni][0] }
-                    else if nbc == ab { added_idxs[ni][1] }
-                    else { added_idxs[ni][2] }
+                    if nab == ab {
+                        added_idxs[ni][0]
+                    } else if nbc == ab {
+                        added_idxs[ni][1]
+                    } else {
+                        added_idxs[ni][2]
+                    }
                 } else {
                     let v = vindex;
                     vindex += 1;
@@ -336,9 +405,13 @@ mod tests {
                     let nab = sort_pair(tabc[ni].a, tabc[ni].b);
                     let nbc = sort_pair(tabc[ni].b, tabc[ni].c);
                     let bc = sort_pair(b, c);
-                    if nab == bc { added_idxs[ni][0] }
-                    else if nbc == bc { added_idxs[ni][1] }
-                    else { added_idxs[ni][2] }
+                    if nab == bc {
+                        added_idxs[ni][0]
+                    } else if nbc == bc {
+                        added_idxs[ni][1]
+                    } else {
+                        added_idxs[ni][2]
+                    }
                 } else {
                     let v = vindex;
                     vindex += 1;
@@ -354,9 +427,13 @@ mod tests {
                     let nab = sort_pair(tabc[ni].a, tabc[ni].b);
                     let nbc = sort_pair(tabc[ni].b, tabc[ni].c);
                     let ca = sort_pair(c, a);
-                    if nab == ca { added_idxs[ni][0] }
-                    else if nbc == ca { added_idxs[ni][1] }
-                    else { added_idxs[ni][2] }
+                    if nab == ca {
+                        added_idxs[ni][0]
+                    } else if nbc == ca {
+                        added_idxs[ni][1]
+                    } else {
+                        added_idxs[ni][2]
+                    }
                 } else {
                     let v = vindex;
                     vindex += 1;
@@ -368,13 +445,38 @@ mod tests {
 
             let base = start_tindex + tdiv_index * 4;
             while tabc.len() <= base + 3 {
-                tabc.push(Triangle { a: 0, b: 0, c: 0, w: 0 });
+                tabc.push(Triangle {
+                    a: 0,
+                    b: 0,
+                    c: 0,
+                    w: 0,
+                });
             }
 
-            tabc[base] = Triangle { a, b: new_vertex_ab, c: new_vertex_ca, w: 0 };
-            tabc[base + 1] = Triangle { a: new_vertex_ab, b, c: new_vertex_bc, w: 0 };
-            tabc[base + 2] = Triangle { a: new_vertex_ca, b: new_vertex_bc, c, w: 0 };
-            tabc[base + 3] = Triangle { a: new_vertex_bc, b: new_vertex_ca, c: new_vertex_ab, w: 0 };
+            tabc[base] = Triangle {
+                a,
+                b: new_vertex_ab,
+                c: new_vertex_ca,
+                w: 0,
+            };
+            tabc[base + 1] = Triangle {
+                a: new_vertex_ab,
+                b,
+                c: new_vertex_bc,
+                w: 0,
+            };
+            tabc[base + 2] = Triangle {
+                a: new_vertex_ca,
+                b: new_vertex_bc,
+                c,
+                w: 0,
+            };
+            tabc[base + 3] = Triangle {
+                a: new_vertex_bc,
+                b: new_vertex_ca,
+                c: new_vertex_ab,
+                w: 0,
+            };
 
             added_idxs[i] = [new_vertex_ab, new_vertex_bc, new_vertex_ca];
             tdiv_index += 1;
@@ -384,7 +486,10 @@ mod tests {
 
         // Without deduplication, 2 triangles * 3 edges = 6 new vertices.
         // With deduplication of the shared edge (1,2), we expect 5 new vertices.
-        assert_eq!(num_new_verts, 5, "Expected 5 new vertices (one shared edge deduped)");
+        assert_eq!(
+            num_new_verts, 5,
+            "Expected 5 new vertices (one shared edge deduped)"
+        );
 
         // Verify we produced 8 child triangles (4 per parent)
         assert_eq!(tdiv_index, 2);
@@ -393,7 +498,9 @@ mod tests {
         // Verify the shared midpoint: tri0's BC midpoint should equal tri1's CA midpoint
         let tri0_bc_mid = added_idxs[0][1]; // BC of tri 0
         let tri1_ca_mid = added_idxs[1][2]; // CA of tri 1
-        assert_eq!(tri0_bc_mid, tri1_ca_mid,
-            "Shared edge (1,2) should produce the same midpoint vertex");
+        assert_eq!(
+            tri0_bc_mid, tri1_ca_mid,
+            "Shared edge (1,2) should produce the same midpoint vertex"
+        );
     }
 }

--- a/rust/src/algo/final_state.rs
+++ b/rust/src/algo/final_state.rs
@@ -1,0 +1,227 @@
+use godot::builtin::Vector3;
+use godot::classes::RenderingDevice;
+use godot::prelude::godot_print;
+
+use crate::buffer_info::BufferInfo;
+use crate::compute_utils;
+use crate::state::CesState;
+
+const SHADER_PATH: &str = "res://addons/celestial_sim_rust/shaders/CreateFinalOutput.slang";
+
+/// GPU-side output buffers from the final compaction step.
+pub struct GpuFinalOutput {
+    pub pos: Option<BufferInfo>,
+    pub tris: Option<BufferInfo>,
+    pub color: Option<BufferInfo>,
+    pub n_visible_tris: u32,
+}
+
+/// CPU-side final mesh output.
+pub struct FinalOutput {
+    pub tris: Vec<i32>,
+    pub color: Vec<[f32; 2]>,
+    pub normals: Vec<Vector3>,
+    pub pos: Vec<Vector3>,
+}
+
+/// Creates the final compacted mesh output (GPU dispatch + CPU readback).
+/// Mirrors C# `CesFinalState.CreateFinalOutput`.
+pub fn create_final_output(
+    rd: &mut RenderingDevice,
+    state: &CesState,
+    _low_poly: bool,
+) -> FinalOutput {
+    let gpu_output = create_final_output_gpu(rd, state);
+    godot_print!(
+        "Number of invisible (deactivate + parents) triangles: {}",
+        state.n_tris - gpu_output.n_visible_tris
+    );
+    read_final_output_to_cpu(rd, gpu_output, true)
+}
+
+/// Dispatches the CreateFinalOutput shader to produce a compacted mesh on the GPU.
+/// Mirrors C# `CesFinalState.CreateFinalOutputGpu`.
+pub fn create_final_output_gpu(rd: &mut RenderingDevice, state: &CesState) -> GpuFinalOutput {
+    let div_mask = state.get_divided_mask(rd);
+    let deactivated_mask = state.get_t_deactivated_mask(rd);
+
+    let visible_mask: Vec<i32> = div_mask
+        .iter()
+        .zip(deactivated_mask.iter())
+        .map(|(&d, &a)| if d == 0 && a == 0 { 1 } else { 0 })
+        .collect();
+
+    let visible_mask_buffer = compute_utils::create_storage_buffer(rd, &visible_mask);
+
+    let mut prefix = visible_mask.clone();
+    compute_utils::sum_array_in_place(&mut prefix, false);
+
+    let n_visible_tris = if prefix.is_empty() {
+        0u32
+    } else {
+        prefix[prefix.len() - 1] as u32
+    };
+
+    if n_visible_tris == 0 || state.n_tris == 0 {
+        rd.free_rid(visible_mask_buffer.rid);
+        return GpuFinalOutput {
+            pos: None,
+            tris: None,
+            color: None,
+            n_visible_tris,
+        };
+    }
+
+    let visible_prefix_buffer = compute_utils::create_storage_buffer(rd, &prefix);
+
+    let vertex_count = n_visible_tris * 3;
+    let out_pos = compute_utils::create_empty_storage_buffer(
+        rd,
+        vertex_count * 4 * std::mem::size_of::<f32>() as u32,
+    );
+    let out_tris = compute_utils::create_empty_storage_buffer(
+        rd,
+        vertex_count * std::mem::size_of::<i32>() as u32,
+    );
+    let out_color = compute_utils::create_empty_storage_buffer(
+        rd,
+        vertex_count * 2 * std::mem::size_of::<f32>() as u32,
+    );
+
+    let n_tris_buf = compute_utils::create_uniform_buffer(rd, &state.n_tris);
+    let n_visible_buf = compute_utils::create_uniform_buffer(rd, &n_visible_tris);
+
+    let buffers: Vec<&BufferInfo> = vec![
+        &state.v_pos,           // 0
+        &state.t_abc,           // 1
+        &state.t_parent,        // 2
+        &state.t_neight_ab,     // 3
+        &state.t_neight_bc,     // 4
+        &state.t_neight_ca,     // 5
+        &state.t_lv,            // 6
+        &visible_mask_buffer,   // 7
+        &visible_prefix_buffer, // 8
+        &out_pos,               // 9
+        &out_tris,              // 10
+        &out_color,             // 11
+        &n_tris_buf,            // 12
+        &n_visible_buf,         // 13
+    ];
+
+    compute_utils::dispatch_shader(rd, SHADER_PATH, &buffers, state.n_tris);
+
+    rd.free_rid(visible_mask_buffer.rid);
+    rd.free_rid(visible_prefix_buffer.rid);
+    rd.free_rid(n_tris_buf.rid);
+    rd.free_rid(n_visible_buf.rid);
+
+    GpuFinalOutput {
+        pos: Some(out_pos),
+        tris: Some(out_tris),
+        color: Some(out_color),
+        n_visible_tris,
+    }
+}
+
+/// Reads GPU final output back to CPU arrays.
+/// Mirrors C# `CesFinalState.ReadFinalOutputToCpu`.
+pub fn read_final_output_to_cpu(
+    rd: &mut RenderingDevice,
+    gpu_output: GpuFinalOutput,
+    free_buffers: bool,
+) -> FinalOutput {
+    let vertex_count = gpu_output.n_visible_tris as usize * 3;
+    if vertex_count == 0 {
+        return FinalOutput {
+            tris: vec![],
+            color: vec![],
+            normals: vec![],
+            pos: vec![],
+        };
+    }
+
+    let pos_buf = gpu_output.pos.as_ref().unwrap();
+    let tris_buf = gpu_output.tris.as_ref().unwrap();
+    let color_buf = gpu_output.color.as_ref().unwrap();
+
+    let pos = compute_utils::convert_v4_buffer_to_vec3(rd, pos_buf);
+    let tris: Vec<i32> = compute_utils::convert_buffer_to_vec(rd, tris_buf);
+    let color_floats: Vec<f32> = compute_utils::convert_buffer_to_vec(rd, color_buf);
+
+    let color: Vec<[f32; 2]> = (0..vertex_count)
+        .map(|i| [color_floats[i * 2], color_floats[i * 2 + 1]])
+        .collect();
+
+    let normals = vec![Vector3::ZERO; pos.len()];
+
+    if free_buffers {
+        if let Some(ref b) = gpu_output.pos {
+            rd.free_rid(b.rid);
+        }
+        if let Some(ref b) = gpu_output.tris {
+            rd.free_rid(b.rid);
+        }
+        if let Some(ref b) = gpu_output.color {
+            rd.free_rid(b.rid);
+        }
+    }
+
+    FinalOutput {
+        tris,
+        color,
+        normals,
+        pos,
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_visible_mask_computation() {
+        // Test that the visibility mask logic is correct:
+        // visible when both divided == 0 AND deactivated == 0
+        let div_mask = vec![0, 1, 0, 0, 1];
+        let deact_mask = vec![0, 0, 1, 0, 0];
+        let visible: Vec<i32> = div_mask
+            .iter()
+            .zip(deact_mask.iter())
+            .map(|(&d, &a)| if d == 0 && a == 0 { 1 } else { 0 })
+            .collect();
+        assert_eq!(visible, vec![1, 0, 0, 1, 0]);
+    }
+
+    #[test]
+    fn test_visible_prefix_sum() {
+        let mut visible = vec![1, 0, 0, 1, 0];
+        crate::compute_utils::sum_array_in_place(&mut visible, false);
+        assert_eq!(visible, vec![1, 1, 1, 2, 2]);
+        assert_eq!(*visible.last().unwrap(), 2); // 2 visible tris
+    }
+
+    #[test]
+    fn test_empty_final_output() {
+        let output = FinalOutput {
+            tris: vec![],
+            color: vec![],
+            normals: vec![],
+            pos: vec![],
+        };
+        assert!(output.tris.is_empty());
+        assert!(output.pos.is_empty());
+    }
+
+    #[test]
+    fn test_color_float_to_pairs() {
+        // Test that color float array -> [f32; 2] pairs works correctly
+        let color_floats: Vec<f32> = vec![1.0, 0.0, 2.0, 0.0, 3.0, 0.0];
+        let vertex_count = 3usize;
+        let color: Vec<[f32; 2]> = (0..vertex_count)
+            .map(|i| [color_floats[i * 2], color_floats[i * 2 + 1]])
+            .collect();
+        assert_eq!(color[0], [1.0, 0.0]);
+        assert_eq!(color[1], [2.0, 0.0]);
+        assert_eq!(color[2], [3.0, 0.0]);
+    }
+}

--- a/rust/src/algo/final_state.rs
+++ b/rust/src/algo/final_state.rs
@@ -1,5 +1,6 @@
 use godot::builtin::Vector3;
 use godot::classes::RenderingDevice;
+use godot::obj::Gd;
 use godot::prelude::godot_print;
 
 use crate::buffer_info::BufferInfo;
@@ -27,7 +28,7 @@ pub struct FinalOutput {
 /// Creates the final compacted mesh output (GPU dispatch + CPU readback).
 /// Mirrors C# `CesFinalState.CreateFinalOutput`.
 pub fn create_final_output(
-    rd: &mut RenderingDevice,
+    rd: &mut Gd<RenderingDevice>,
     state: &CesState,
     _low_poly: bool,
 ) -> FinalOutput {
@@ -41,7 +42,7 @@ pub fn create_final_output(
 
 /// Dispatches the CreateFinalOutput shader to produce a compacted mesh on the GPU.
 /// Mirrors C# `CesFinalState.CreateFinalOutputGpu`.
-pub fn create_final_output_gpu(rd: &mut RenderingDevice, state: &CesState) -> GpuFinalOutput {
+pub fn create_final_output_gpu(rd: &mut Gd<RenderingDevice>, state: &CesState) -> GpuFinalOutput {
     let div_mask = state.get_divided_mask(rd);
     let deactivated_mask = state.get_t_deactivated_mask(rd);
 
@@ -63,7 +64,7 @@ pub fn create_final_output_gpu(rd: &mut RenderingDevice, state: &CesState) -> Gp
     };
 
     if n_visible_tris == 0 || state.n_tris == 0 {
-        rd.free_rid(visible_mask_buffer.rid);
+        compute_utils::free_rid_on_render_thread(rd, visible_mask_buffer.rid);
         return GpuFinalOutput {
             pos: None,
             tris: None,
@@ -110,10 +111,10 @@ pub fn create_final_output_gpu(rd: &mut RenderingDevice, state: &CesState) -> Gp
 
     compute_utils::dispatch_shader(rd, SHADER_PATH, &buffers, state.n_tris);
 
-    rd.free_rid(visible_mask_buffer.rid);
-    rd.free_rid(visible_prefix_buffer.rid);
-    rd.free_rid(n_tris_buf.rid);
-    rd.free_rid(n_visible_buf.rid);
+    compute_utils::free_rid_on_render_thread(rd, visible_mask_buffer.rid);
+    compute_utils::free_rid_on_render_thread(rd, visible_prefix_buffer.rid);
+    compute_utils::free_rid_on_render_thread(rd, n_tris_buf.rid);
+    compute_utils::free_rid_on_render_thread(rd, n_visible_buf.rid);
 
     GpuFinalOutput {
         pos: Some(out_pos),
@@ -126,7 +127,7 @@ pub fn create_final_output_gpu(rd: &mut RenderingDevice, state: &CesState) -> Gp
 /// Reads GPU final output back to CPU arrays.
 /// Mirrors C# `CesFinalState.ReadFinalOutputToCpu`.
 pub fn read_final_output_to_cpu(
-    rd: &mut RenderingDevice,
+    rd: &mut Gd<RenderingDevice>,
     gpu_output: GpuFinalOutput,
     free_buffers: bool,
 ) -> FinalOutput {
@@ -156,13 +157,13 @@ pub fn read_final_output_to_cpu(
 
     if free_buffers {
         if let Some(ref b) = gpu_output.pos {
-            rd.free_rid(b.rid);
+            compute_utils::free_rid_on_render_thread(rd, b.rid);
         }
         if let Some(ref b) = gpu_output.tris {
-            rd.free_rid(b.rid);
+            compute_utils::free_rid_on_render_thread(rd, b.rid);
         }
         if let Some(ref b) = gpu_output.color {
-            rd.free_rid(b.rid);
+            compute_utils::free_rid_on_render_thread(rd, b.rid);
         }
     }
 

--- a/rust/src/algo/final_state.rs
+++ b/rust/src/algo/final_state.rs
@@ -5,9 +5,22 @@ use godot::prelude::godot_print;
 
 use crate::buffer_info::BufferInfo;
 use crate::compute_utils;
+use crate::compute_utils::ComputePipeline;
 use crate::state::CesState;
 
 const SHADER_PATH: &str = "res://addons/celestial_sim_rust/shaders/CreateFinalOutput.slang";
+
+pub struct FinalStateShader {
+    pipeline: ComputePipeline,
+}
+
+impl FinalStateShader {
+    pub fn new(rd: &mut Gd<RenderingDevice>) -> Self {
+        Self {
+            pipeline: ComputePipeline::new(rd, SHADER_PATH),
+        }
+    }
+}
 
 /// GPU-side output buffers from the final compaction step.
 pub struct GpuFinalOutput {
@@ -31,8 +44,9 @@ pub fn create_final_output(
     rd: &mut Gd<RenderingDevice>,
     state: &CesState,
     _low_poly: bool,
+    shader: &FinalStateShader,
 ) -> FinalOutput {
-    let gpu_output = create_final_output_gpu(rd, state);
+    let gpu_output = create_final_output_gpu(rd, state, shader);
     godot_print!(
         "Number of invisible (deactivate + parents) triangles: {}",
         state.n_tris - gpu_output.n_visible_tris
@@ -42,7 +56,11 @@ pub fn create_final_output(
 
 /// Dispatches the CreateFinalOutput shader to produce a compacted mesh on the GPU.
 /// Mirrors C# `CesFinalState.CreateFinalOutputGpu`.
-pub fn create_final_output_gpu(rd: &mut Gd<RenderingDevice>, state: &CesState) -> GpuFinalOutput {
+pub fn create_final_output_gpu(
+    rd: &mut Gd<RenderingDevice>,
+    state: &CesState,
+    shader: &FinalStateShader,
+) -> GpuFinalOutput {
     let div_mask = state.get_divided_mask(rd);
     let deactivated_mask = state.get_t_deactivated_mask(rd);
 
@@ -89,7 +107,6 @@ pub fn create_final_output_gpu(rd: &mut Gd<RenderingDevice>, state: &CesState) -
         vertex_count * 2 * std::mem::size_of::<f32>() as u32,
     );
 
-    let n_tris_buf = compute_utils::create_uniform_buffer(rd, &state.n_tris);
     let n_visible_buf = compute_utils::create_uniform_buffer(rd, &n_visible_tris);
 
     let buffers: Vec<&BufferInfo> = vec![
@@ -105,15 +122,14 @@ pub fn create_final_output_gpu(rd: &mut Gd<RenderingDevice>, state: &CesState) -
         &out_pos,               // 9
         &out_tris,              // 10
         &out_color,             // 11
-        &n_tris_buf,            // 12
+        &state.u_n_tris,        // 12
         &n_visible_buf,         // 13
     ];
 
-    compute_utils::dispatch_shader(rd, SHADER_PATH, &buffers, state.n_tris);
+    shader.pipeline.dispatch(rd, &buffers, state.n_tris);
 
     compute_utils::free_rid_on_render_thread(rd, visible_mask_buffer.rid);
     compute_utils::free_rid_on_render_thread(rd, visible_prefix_buffer.rid);
-    compute_utils::free_rid_on_render_thread(rd, n_tris_buf.rid);
     compute_utils::free_rid_on_render_thread(rd, n_visible_buf.rid);
 
     GpuFinalOutput {

--- a/rust/src/algo/mark_tris.rs
+++ b/rust/src/algo/mark_tris.rs
@@ -4,55 +4,70 @@ use godot::obj::Gd;
 
 use crate::buffer_info::BufferInfo;
 use crate::compute_utils;
+use crate::compute_utils::ComputePipeline;
 use crate::state::CesState;
 
 const SHADER_PATH: &str = "res://addons/celestial_sim_rust/shaders/MarkTrisToDivide.slang";
 
-/// Dispatches the MarkTrisToDivide shader to flag triangles whose screen-space
-/// area exceeds `max_tri_size`. Mirrors C# `CesMarkTrisToDivide.FlagLargeTrisToDivide`.
-pub fn flag_large_tris_to_divide(
-    rd: &mut Gd<RenderingDevice>,
-    state: &CesState,
-    camera_pos: Vector3,
-    max_divs: u32,
-    radius: f32,
-    max_tri_size: f32,
-) {
-    // Temporary storage buffer for per-triangle sizes
-    let tris_size = compute_utils::create_storage_buffer(rd, &vec![0.0f32; state.n_tris as usize]);
+pub struct MarkTrisShader {
+    pipeline: ComputePipeline,
+}
 
-    // Uniform buffers for shader parameters
-    let camera_pos_arr: [f32; 3] = [camera_pos.x, camera_pos.y, camera_pos.z];
-    let camera_pos_buf = compute_utils::create_uniform_buffer(rd, &camera_pos_arr);
-    let max_divs_buf = compute_utils::create_uniform_buffer(rd, &max_divs);
-    let radius_buf = compute_utils::create_uniform_buffer(rd, &radius);
-    let max_tri_size_buf = compute_utils::create_uniform_buffer(rd, &max_tri_size);
+impl MarkTrisShader {
+    pub fn new(rd: &mut Gd<RenderingDevice>) -> Self {
+        Self {
+            pipeline: ComputePipeline::new(rd, SHADER_PATH),
+        }
+    }
 
-    let buffers: Vec<&BufferInfo> = vec![
-        &state.v_pos,              // 0
-        &state.t_abc,              // 1
-        &state.t_lv,               // 2
-        &state.t_divided,          // 3
-        &state.t_to_divide_mask,   // 4
-        &camera_pos_buf,           // 5
-        &max_divs_buf,             // 6
-        &radius_buf,               // 7
-        &max_tri_size_buf,         // 8
-        &tris_size,                // 9
-        &state.t_neight_ab,        // 10
-        &state.t_neight_bc,        // 11
-        &state.t_neight_ca,        // 12
-        &state.t_deactivated,      // 13
-        &state.t_to_merge_mask,    // 14
-        &state.t_parent,           // 15
-    ];
+    /// Dispatches the MarkTrisToDivide shader to flag triangles whose screen-space
+    /// area exceeds `max_tri_size`. Mirrors C# `CesMarkTrisToDivide.FlagLargeTrisToDivide`.
+    pub fn flag_large_tris_to_divide(
+        &self,
+        rd: &mut Gd<RenderingDevice>,
+        state: &CesState,
+        camera_pos: Vector3,
+        max_divs: u32,
+        radius: f32,
+        max_tri_size: f32,
+    ) {
+        // Temporary storage buffer for per-triangle sizes
+        let tris_size =
+            compute_utils::create_storage_buffer(rd, &vec![0.0f32; state.n_tris as usize]);
 
-    compute_utils::dispatch_shader(rd, SHADER_PATH, &buffers, state.n_tris);
+        // Uniform buffers for shader parameters
+        let camera_pos_arr: [f32; 3] = [camera_pos.x, camera_pos.y, camera_pos.z];
+        let camera_pos_buf = compute_utils::create_uniform_buffer(rd, &camera_pos_arr);
+        let max_divs_buf = compute_utils::create_uniform_buffer(rd, &max_divs);
+        let radius_buf = compute_utils::create_uniform_buffer(rd, &radius);
+        let max_tri_size_buf = compute_utils::create_uniform_buffer(rd, &max_tri_size);
 
-    // Free temporary buffers
-    compute_utils::free_rid_on_render_thread(rd, tris_size.rid);
-    compute_utils::free_rid_on_render_thread(rd, camera_pos_buf.rid);
-    compute_utils::free_rid_on_render_thread(rd, max_divs_buf.rid);
-    compute_utils::free_rid_on_render_thread(rd, radius_buf.rid);
-    compute_utils::free_rid_on_render_thread(rd, max_tri_size_buf.rid);
+        let buffers: Vec<&BufferInfo> = vec![
+            &state.v_pos,            // 0
+            &state.t_abc,            // 1
+            &state.t_lv,             // 2
+            &state.t_divided,        // 3
+            &state.t_to_divide_mask, // 4
+            &camera_pos_buf,         // 5
+            &max_divs_buf,           // 6
+            &radius_buf,             // 7
+            &max_tri_size_buf,       // 8
+            &tris_size,              // 9
+            &state.t_neight_ab,      // 10
+            &state.t_neight_bc,      // 11
+            &state.t_neight_ca,      // 12
+            &state.t_deactivated,    // 13
+            &state.t_to_merge_mask,  // 14
+            &state.t_parent,         // 15
+        ];
+
+        self.pipeline.dispatch(rd, &buffers, state.n_tris);
+
+        // Free temporary buffers
+        compute_utils::free_rid_on_render_thread(rd, tris_size.rid);
+        compute_utils::free_rid_on_render_thread(rd, camera_pos_buf.rid);
+        compute_utils::free_rid_on_render_thread(rd, max_divs_buf.rid);
+        compute_utils::free_rid_on_render_thread(rd, radius_buf.rid);
+        compute_utils::free_rid_on_render_thread(rd, max_tri_size_buf.rid);
+    }
 }

--- a/rust/src/algo/mark_tris.rs
+++ b/rust/src/algo/mark_tris.rs
@@ -1,5 +1,6 @@
 use godot::builtin::Vector3;
 use godot::classes::RenderingDevice;
+use godot::obj::Gd;
 
 use crate::buffer_info::BufferInfo;
 use crate::compute_utils;
@@ -10,7 +11,7 @@ const SHADER_PATH: &str = "res://addons/celestial_sim_rust/shaders/MarkTrisToDiv
 /// Dispatches the MarkTrisToDivide shader to flag triangles whose screen-space
 /// area exceeds `max_tri_size`. Mirrors C# `CesMarkTrisToDivide.FlagLargeTrisToDivide`.
 pub fn flag_large_tris_to_divide(
-    rd: &mut RenderingDevice,
+    rd: &mut Gd<RenderingDevice>,
     state: &CesState,
     camera_pos: Vector3,
     max_divs: u32,
@@ -49,9 +50,9 @@ pub fn flag_large_tris_to_divide(
     compute_utils::dispatch_shader(rd, SHADER_PATH, &buffers, state.n_tris);
 
     // Free temporary buffers
-    rd.free_rid(tris_size.rid);
-    rd.free_rid(camera_pos_buf.rid);
-    rd.free_rid(max_divs_buf.rid);
-    rd.free_rid(radius_buf.rid);
-    rd.free_rid(max_tri_size_buf.rid);
+    compute_utils::free_rid_on_render_thread(rd, tris_size.rid);
+    compute_utils::free_rid_on_render_thread(rd, camera_pos_buf.rid);
+    compute_utils::free_rid_on_render_thread(rd, max_divs_buf.rid);
+    compute_utils::free_rid_on_render_thread(rd, radius_buf.rid);
+    compute_utils::free_rid_on_render_thread(rd, max_tri_size_buf.rid);
 }

--- a/rust/src/algo/merge_lod.rs
+++ b/rust/src/algo/merge_lod.rs
@@ -3,6 +3,7 @@ use godot::obj::Gd;
 
 use crate::buffer_info::BufferInfo;
 use crate::compute_utils;
+use crate::compute_utils::ComputePipeline;
 use crate::state::CesState;
 
 const SHADER_PATH: &str = "res://addons/celestial_sim_rust/shaders/MergeLOD.slang";
@@ -16,53 +17,65 @@ fn extract_merge_indices(mask: &[i32]) -> Vec<u32> {
         .collect()
 }
 
-/// Performs triangle merging. Mirrors C# `CesMergeLOD.MakeMerge()`.
-///
-/// Returns the number of triangles merged (0 if nothing to merge).
-pub fn make_merge(rd: &mut Gd<RenderingDevice>, state: &mut CesState) -> u32 {
-    let merge_mask = state.get_t_to_merge_mask(rd);
-    let idxs_to_merge = extract_merge_indices(&merge_mask);
+pub struct MergeShader {
+    pipeline: ComputePipeline,
+}
 
-    let n_tris_to_merge = idxs_to_merge.len() as u32;
-    if n_tris_to_merge == 0 {
-        return 0;
+impl MergeShader {
+    pub fn new(rd: &mut Gd<RenderingDevice>) -> Self {
+        Self {
+            pipeline: ComputePipeline::new(rd, SHADER_PATH),
+        }
     }
 
-    let indices_to_merge_buf = compute_utils::create_storage_buffer(rd, &idxs_to_merge);
-    let tris_output_buf =
-        compute_utils::create_storage_buffer(rd, &vec![0.0f32; n_tris_to_merge as usize]);
-    let n_tris_to_merge_buf = compute_utils::create_uniform_buffer(rd, &n_tris_to_merge);
+    /// Performs triangle merging. Mirrors C# `CesMergeLOD.MakeMerge()`.
+    ///
+    /// Returns the number of triangles merged (0 if nothing to merge).
+    pub fn make_merge(&self, rd: &mut Gd<RenderingDevice>, state: &mut CesState) -> u32 {
+        let merge_mask = state.get_t_to_merge_mask(rd);
+        let idxs_to_merge = extract_merge_indices(&merge_mask);
 
-    let buffers: Vec<&BufferInfo> = vec![
-        &state.t_abc,              // 0
-        &state.t_divided,          // 1
-        &n_tris_to_merge_buf,      // 2
-        &state.t_neight_ab,        // 3
-        &state.t_neight_bc,        // 4
-        &state.t_neight_ca,        // 5
-        &state.t_a_t,              // 6
-        &state.t_b_t,              // 7
-        &state.t_c_t,              // 8
-        &state.t_center_t,         // 9
-        &indices_to_merge_buf,     // 10
-        &state.t_to_merge_mask,    // 11
-        &tris_output_buf,          // 12
-        &state.t_deactivated,      // 13
-        &state.t_lv,               // 14
-        &state.v_update_mask,      // 15
-        &state.v_pos,              // 16
-        &state.t_parent,           // 17
-    ];
+        let n_tris_to_merge = idxs_to_merge.len() as u32;
+        if n_tris_to_merge == 0 {
+            return 0;
+        }
 
-    compute_utils::dispatch_shader(rd, SHADER_PATH, &buffers, n_tris_to_merge);
+        let indices_to_merge_buf = compute_utils::create_storage_buffer(rd, &idxs_to_merge);
+        let tris_output_buf =
+            compute_utils::create_storage_buffer(rd, &vec![0.0f32; n_tris_to_merge as usize]);
+        let n_tris_to_merge_buf = compute_utils::create_uniform_buffer(rd, &n_tris_to_merge);
 
-    compute_utils::free_rid_on_render_thread(rd, indices_to_merge_buf.rid);
-    compute_utils::free_rid_on_render_thread(rd, tris_output_buf.rid);
-    compute_utils::free_rid_on_render_thread(rd, n_tris_to_merge_buf.rid);
+        let buffers: Vec<&BufferInfo> = vec![
+            &state.t_abc,           // 0
+            &state.t_divided,       // 1
+            &n_tris_to_merge_buf,   // 2
+            &state.t_neight_ab,     // 3
+            &state.t_neight_bc,     // 4
+            &state.t_neight_ca,     // 5
+            &state.t_a_t,           // 6
+            &state.t_b_t,           // 7
+            &state.t_c_t,           // 8
+            &state.t_center_t,      // 9
+            &indices_to_merge_buf,  // 10
+            &state.t_to_merge_mask, // 11
+            &tris_output_buf,       // 12
+            &state.t_deactivated,   // 13
+            &state.t_lv,            // 14
+            &state.v_update_mask,   // 15
+            &state.v_pos,           // 16
+            &state.t_parent,        // 17
+        ];
 
-    state.n_deactivated_tris += n_tris_to_merge;
+        self.pipeline.dispatch(rd, &buffers, n_tris_to_merge);
 
-    n_tris_to_merge
+        compute_utils::free_rid_on_render_thread(rd, indices_to_merge_buf.rid);
+        compute_utils::free_rid_on_render_thread(rd, tris_output_buf.rid);
+        compute_utils::free_rid_on_render_thread(rd, n_tris_to_merge_buf.rid);
+
+        state.n_deactivated_tris += n_tris_to_merge;
+
+        n_tris_to_merge
+    }
 }
 
 #[cfg(test)]

--- a/rust/src/algo/merge_lod.rs
+++ b/rust/src/algo/merge_lod.rs
@@ -1,4 +1,5 @@
 use godot::classes::RenderingDevice;
+use godot::obj::Gd;
 
 use crate::buffer_info::BufferInfo;
 use crate::compute_utils;
@@ -18,7 +19,7 @@ fn extract_merge_indices(mask: &[i32]) -> Vec<u32> {
 /// Performs triangle merging. Mirrors C# `CesMergeLOD.MakeMerge()`.
 ///
 /// Returns the number of triangles merged (0 if nothing to merge).
-pub fn make_merge(rd: &mut RenderingDevice, state: &mut CesState) -> u32 {
+pub fn make_merge(rd: &mut Gd<RenderingDevice>, state: &mut CesState) -> u32 {
     let merge_mask = state.get_t_to_merge_mask(rd);
     let idxs_to_merge = extract_merge_indices(&merge_mask);
 
@@ -55,9 +56,9 @@ pub fn make_merge(rd: &mut RenderingDevice, state: &mut CesState) -> u32 {
 
     compute_utils::dispatch_shader(rd, SHADER_PATH, &buffers, n_tris_to_merge);
 
-    rd.free_rid(indices_to_merge_buf.rid);
-    rd.free_rid(tris_output_buf.rid);
-    rd.free_rid(n_tris_to_merge_buf.rid);
+    compute_utils::free_rid_on_render_thread(rd, indices_to_merge_buf.rid);
+    compute_utils::free_rid_on_render_thread(rd, tris_output_buf.rid);
+    compute_utils::free_rid_on_render_thread(rd, n_tris_to_merge_buf.rid);
 
     state.n_deactivated_tris += n_tris_to_merge;
 

--- a/rust/src/algo/merge_lod.rs
+++ b/rust/src/algo/merge_lod.rs
@@ -1,0 +1,91 @@
+use godot::classes::RenderingDevice;
+
+use crate::buffer_info::BufferInfo;
+use crate::compute_utils;
+use crate::state::CesState;
+
+const SHADER_PATH: &str = "res://addons/celestial_sim_rust/shaders/MergeLOD.slang";
+
+/// Extracts indices where the mask value is non-zero.
+fn extract_merge_indices(mask: &[i32]) -> Vec<u32> {
+    mask.iter()
+        .enumerate()
+        .filter(|(_, &v)| v != 0)
+        .map(|(i, _)| i as u32)
+        .collect()
+}
+
+/// Performs triangle merging. Mirrors C# `CesMergeLOD.MakeMerge()`.
+///
+/// Returns the number of triangles merged (0 if nothing to merge).
+pub fn make_merge(rd: &mut RenderingDevice, state: &mut CesState) -> u32 {
+    let merge_mask = state.get_t_to_merge_mask(rd);
+    let idxs_to_merge = extract_merge_indices(&merge_mask);
+
+    let n_tris_to_merge = idxs_to_merge.len() as u32;
+    if n_tris_to_merge == 0 {
+        return 0;
+    }
+
+    let indices_to_merge_buf = compute_utils::create_storage_buffer(rd, &idxs_to_merge);
+    let tris_output_buf =
+        compute_utils::create_storage_buffer(rd, &vec![0.0f32; n_tris_to_merge as usize]);
+    let n_tris_to_merge_buf = compute_utils::create_uniform_buffer(rd, &n_tris_to_merge);
+
+    let buffers: Vec<&BufferInfo> = vec![
+        &state.t_abc,              // 0
+        &state.t_divided,          // 1
+        &n_tris_to_merge_buf,      // 2
+        &state.t_neight_ab,        // 3
+        &state.t_neight_bc,        // 4
+        &state.t_neight_ca,        // 5
+        &state.t_a_t,              // 6
+        &state.t_b_t,              // 7
+        &state.t_c_t,              // 8
+        &state.t_center_t,         // 9
+        &indices_to_merge_buf,     // 10
+        &state.t_to_merge_mask,    // 11
+        &tris_output_buf,          // 12
+        &state.t_deactivated,      // 13
+        &state.t_lv,               // 14
+        &state.v_update_mask,      // 15
+        &state.v_pos,              // 16
+        &state.t_parent,           // 17
+    ];
+
+    compute_utils::dispatch_shader(rd, SHADER_PATH, &buffers, n_tris_to_merge);
+
+    rd.free_rid(indices_to_merge_buf.rid);
+    rd.free_rid(tris_output_buf.rid);
+    rd.free_rid(n_tris_to_merge_buf.rid);
+
+    state.n_deactivated_tris += n_tris_to_merge;
+
+    n_tris_to_merge
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_merge_indices_extraction() {
+        let mask = vec![0i32, 1, 0, 1, 0];
+        let indices = extract_merge_indices(&mask);
+        assert_eq!(indices, vec![1, 3]);
+    }
+
+    #[test]
+    fn test_merge_indices_extraction_empty() {
+        let mask = vec![0i32, 0, 0, 0];
+        let indices = extract_merge_indices(&mask);
+        assert!(indices.is_empty());
+    }
+
+    #[test]
+    fn test_merge_indices_extraction_all_set() {
+        let mask = vec![1i32, 2, 3];
+        let indices = extract_merge_indices(&mask);
+        assert_eq!(indices, vec![0, 1, 2]);
+    }
+}

--- a/rust/src/algo/mod.rs
+++ b/rust/src/algo/mod.rs
@@ -1,2 +1,5 @@
+pub mod compact_buffers;
 pub mod div_lod;
 pub mod mark_tris;
+pub mod merge_lod;
+pub mod update_neighbors;

--- a/rust/src/algo/mod.rs
+++ b/rust/src/algo/mod.rs
@@ -1,5 +1,7 @@
 pub mod compact_buffers;
 pub mod div_lod;
+pub mod final_state;
 pub mod mark_tris;
 pub mod merge_lod;
+pub mod run_algo;
 pub mod update_neighbors;

--- a/rust/src/algo/run_algo.rs
+++ b/rust/src/algo/run_algo.rs
@@ -4,12 +4,12 @@ use godot::obj::Gd;
 use godot::prelude::godot_print;
 use std::time::{Duration, Instant};
 
-use crate::algo::compact_buffers;
-use crate::algo::div_lod;
-use crate::algo::final_state;
-use crate::algo::mark_tris;
-use crate::algo::merge_lod;
-use crate::algo::update_neighbors;
+use crate::algo::compact_buffers::CompactShaders;
+use crate::algo::div_lod::DivShader;
+use crate::algo::final_state::{self, FinalStateShader};
+use crate::algo::mark_tris::MarkTrisShader;
+use crate::algo::merge_lod::MergeShader;
+use crate::algo::update_neighbors::UpdateNeighborsShader;
 use crate::initial_state;
 use crate::layers::CesLayer;
 use crate::state::CesState;
@@ -108,6 +108,12 @@ pub struct CesRunAlgo {
     pub normals: Vec<Vector3>,
     pub triangles: Vec<i32>,
     pub sim_value: Vec<[f32; 2]>,
+    mark_tris_shader: Option<MarkTrisShader>,
+    update_neighbors_shader: Option<UpdateNeighborsShader>,
+    div_shader: Option<DivShader>,
+    merge_shader: Option<MergeShader>,
+    compact_shaders: Option<CompactShaders>,
+    final_state_shader: Option<FinalStateShader>,
 }
 
 impl CesRunAlgo {
@@ -118,6 +124,12 @@ impl CesRunAlgo {
             normals: vec![],
             triangles: vec![],
             sim_value: vec![],
+            mark_tris_shader: None,
+            update_neighbors_shader: None,
+            div_shader: None,
+            merge_shader: None,
+            compact_shaders: None,
+            final_state_shader: None,
         }
     }
 
@@ -164,6 +176,15 @@ impl CesRunAlgo {
 
         if self.state.is_none() {
             self.state = Some(initial_state::create_core_state(rd));
+            self.mark_tris_shader = Some(MarkTrisShader::new(rd));
+            self.update_neighbors_shader = Some(UpdateNeighborsShader::new(rd));
+            self.div_shader = Some(DivShader::new(rd));
+            self.merge_shader = Some(MergeShader::new(rd));
+            self.compact_shaders = Some(CompactShaders::new(rd));
+            self.final_state_shader = Some(FinalStateShader::new(rd));
+            for layer in layers.iter_mut() {
+                layer.init_pipeline(rd);
+            }
             Self::layers_update(rd, self.state.as_ref().unwrap(), layers, config.radius);
         }
 
@@ -179,26 +200,37 @@ impl CesRunAlgo {
 
             if !skip_auto_division_marking {
                 let mark_start = Instant::now();
-                mark_tris::flag_large_tris_to_divide(
-                    rd,
-                    state,
-                    cam_local,
-                    config.subdivisions,
-                    config.radius,
-                    config.triangle_screen_size,
-                );
+                self.mark_tris_shader
+                    .as_ref()
+                    .unwrap()
+                    .flag_large_tris_to_divide(
+                        rd,
+                        state,
+                        cam_local,
+                        config.subdivisions,
+                        config.radius,
+                        config.triangle_screen_size,
+                    );
                 timings.mark += mark_start.elapsed();
             }
 
             let divide_start = Instant::now();
-            n_tris_added = div_lod::make_div(rd, state, config.precise_normals);
+            n_tris_added =
+                self.div_shader
+                    .as_ref()
+                    .unwrap()
+                    .make_div(rd, state, config.precise_normals);
             timings.divide += divide_start.elapsed();
-            if n_tris_added > 0 && config.show_debug_messages {
-                godot_print!("Divided {} triangles", n_tris_added / 4);
+            if n_tris_added > 0 {
+                state.sync_n_tris_buffer(rd);
+                state.sync_n_verts_buffer(rd);
+                if config.show_debug_messages {
+                    godot_print!("Divided {} triangles", n_tris_added / 4);
+                }
             }
 
             let merge_start = Instant::now();
-            n_tris_merged = merge_lod::make_merge(rd, state);
+            n_tris_merged = self.merge_shader.as_ref().unwrap().make_merge(rd, state);
             timings.merge += merge_start.elapsed();
             if n_tris_merged > 0 && config.show_debug_messages {
                 godot_print!(
@@ -213,13 +245,16 @@ impl CesRunAlgo {
                     godot_print!("Removing free space inside buffers");
                 }
                 let compact_start = Instant::now();
-                compact_buffers::compact(rd, state);
+                self.compact_shaders.as_ref().unwrap().compact(rd, state);
                 timings.compact += compact_start.elapsed();
             }
 
             if n_tris_added > 0 || n_tris_merged > 0 {
                 let neighbors_start = Instant::now();
-                update_neighbors::update_neighbors(rd, state);
+                self.update_neighbors_shader
+                    .as_ref()
+                    .unwrap()
+                    .update_neighbors(rd, state);
                 timings.neighbors += neighbors_start.elapsed();
             }
 
@@ -229,7 +264,12 @@ impl CesRunAlgo {
         }
 
         let final_start = Instant::now();
-        let final_output = final_state::create_final_output(rd, state, config.low_poly_look);
+        let final_output = final_state::create_final_output(
+            rd,
+            state,
+            config.low_poly_look,
+            self.final_state_shader.as_ref().unwrap(),
+        );
         timings.final_output += final_start.elapsed();
         self.pos = final_output.pos;
         self.normals = final_output.normals;

--- a/rust/src/algo/run_algo.rs
+++ b/rust/src/algo/run_algo.rs
@@ -1,0 +1,170 @@
+use godot::builtin::Vector3;
+use godot::classes::RenderingDevice;
+use godot::prelude::godot_print;
+
+use crate::algo::compact_buffers;
+use crate::algo::div_lod;
+use crate::algo::final_state;
+use crate::algo::mark_tris;
+use crate::algo::merge_lod;
+use crate::algo::update_neighbors;
+use crate::initial_state;
+use crate::layers::CesLayer;
+use crate::state::CesState;
+
+/// Configuration for the subdivision algorithm.
+pub struct RunAlgoConfig {
+    pub subdivisions: u32,
+    pub radius: f32,
+    pub triangle_screen_size: f32,
+    pub precise_normals: bool,
+    pub low_poly_look: bool,
+    pub show_debug_messages: bool,
+}
+
+/// Orchestrates the adaptive LOD subdivision loop.
+/// Mirrors C# `CesRunAlgo`.
+pub struct CesRunAlgo {
+    pub state: Option<CesState>,
+    pub pos: Vec<Vector3>,
+    pub normals: Vec<Vector3>,
+    pub triangles: Vec<i32>,
+    pub sim_value: Vec<[f32; 2]>,
+}
+
+impl CesRunAlgo {
+    pub fn new() -> Self {
+        Self {
+            state: None,
+            pos: vec![],
+            normals: vec![],
+            triangles: vec![],
+            sim_value: vec![],
+        }
+    }
+
+    /// Runs all layers' state initialization and position update.
+    fn layers_update(
+        rd: &mut RenderingDevice,
+        state: &CesState,
+        layers: &mut [Box<dyn CesLayer>],
+        radius: f32,
+    ) {
+        for i in 0..layers.len() {
+            if i == 0 {
+                layers[i].set_state(state, radius);
+            } else {
+                let (prev, current) = layers.split_at_mut(i);
+                current[0].set_state_from_layer(&*prev[i - 1]);
+            }
+            layers[i].update_pos(rd, state);
+        }
+    }
+
+    /// Runs the main subdivision loop until convergence.
+    /// Mirrors C# `CesRunAlgo.UpdateTriangleGraph`.
+    pub fn update_triangle_graph(
+        &mut self,
+        rd: &mut RenderingDevice,
+        cam_local: Vector3,
+        config: &RunAlgoConfig,
+        layers: &mut [Box<dyn CesLayer>],
+        skip_auto_division_marking: bool,
+    ) {
+        if self.state.is_none() {
+            self.state = Some(initial_state::create_core_state(rd));
+            Self::layers_update(rd, self.state.as_ref().unwrap(), layers, config.radius);
+        }
+
+        let state = self.state.as_mut().unwrap();
+
+        let mut n_tris_added: u32 = 0;
+        let mut n_tris_merged: u32 = 0;
+        let mut first_run = true;
+
+        while n_tris_added > 0 || n_tris_merged > 0 || first_run {
+            first_run = false;
+
+            if !skip_auto_division_marking {
+                mark_tris::flag_large_tris_to_divide(
+                    rd,
+                    state,
+                    cam_local,
+                    config.subdivisions,
+                    config.radius,
+                    config.triangle_screen_size,
+                );
+            }
+
+            n_tris_added = div_lod::make_div(rd, state, config.precise_normals);
+            if n_tris_added > 0 && config.show_debug_messages {
+                godot_print!("Divided {} triangles", n_tris_added / 4);
+            }
+
+            n_tris_merged = merge_lod::make_merge(rd, state);
+            if n_tris_merged > 0 && config.show_debug_messages {
+                godot_print!(
+                    "Merged {} triangle(s) (removed {} child triangles)",
+                    n_tris_merged / 4,
+                    n_tris_merged
+                );
+            }
+
+            if state.n_deactivated_tris > 100_000 {
+                if config.show_debug_messages {
+                    godot_print!("Removing free space inside buffers");
+                }
+                compact_buffers::compact(rd, state);
+            }
+
+            if n_tris_added > 0 || n_tris_merged > 0 {
+                update_neighbors::update_neighbors(rd, state);
+            }
+
+            Self::layers_update(rd, state, layers, config.radius);
+        }
+
+        let final_output = final_state::create_final_output(rd, state, config.low_poly_look);
+        self.pos = final_output.pos;
+        self.normals = final_output.normals;
+        self.triangles = final_output.tris;
+        self.sim_value = final_output.color;
+    }
+
+    /// Frees all GPU resources held by the state.
+    pub fn dispose(&mut self, rd: &mut RenderingDevice) {
+        if let Some(ref state) = self.state {
+            state.dispose(rd);
+        }
+        self.state = None;
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_run_algo_config_defaults() {
+        let config = RunAlgoConfig {
+            subdivisions: 3,
+            radius: 1.0,
+            triangle_screen_size: 0.1,
+            precise_normals: false,
+            low_poly_look: false,
+            show_debug_messages: false,
+        };
+        assert_eq!(config.subdivisions, 3);
+        assert_eq!(config.radius, 1.0);
+    }
+
+    #[test]
+    fn test_run_algo_initial_state() {
+        let algo = CesRunAlgo::new();
+        assert!(algo.state.is_none());
+        assert!(algo.pos.is_empty());
+        assert!(algo.normals.is_empty());
+        assert!(algo.triangles.is_empty());
+        assert!(algo.sim_value.is_empty());
+    }
+}

--- a/rust/src/algo/run_algo.rs
+++ b/rust/src/algo/run_algo.rs
@@ -1,6 +1,7 @@
 use godot::builtin::Vector3;
 use godot::classes::RenderingDevice;
 use godot::prelude::godot_print;
+use std::time::{Duration, Instant};
 
 use crate::algo::compact_buffers;
 use crate::algo::div_lod;
@@ -20,6 +21,82 @@ pub struct RunAlgoConfig {
     pub precise_normals: bool,
     pub low_poly_look: bool,
     pub show_debug_messages: bool,
+}
+
+struct AlgoTimingTotals {
+    total: Duration,
+    mark: Duration,
+    divide: Duration,
+    merge: Duration,
+    compact: Duration,
+    neighbors: Duration,
+    layers: Duration,
+    final_output: Duration,
+    iterations: u32,
+}
+
+impl AlgoTimingTotals {
+    fn print_summary(&self) {
+        godot_print!(
+            "AlgoTiming summary: iterations={} total={:.3} ms",
+            self.iterations,
+            self.total.as_secs_f64() * 1000.0
+        );
+        godot_print!(
+            "AlgoTiming step MarkTrisToDivide: {:.3} ms",
+            self.mark.as_secs_f64() * 1000.0
+        );
+        godot_print!(
+            "AlgoTiming step Divide: {:.3} ms",
+            self.divide.as_secs_f64() * 1000.0
+        );
+        godot_print!(
+            "AlgoTiming step Merge: {:.3} ms",
+            self.merge.as_secs_f64() * 1000.0
+        );
+        godot_print!(
+            "AlgoTiming step Compact: {:.3} ms",
+            self.compact.as_secs_f64() * 1000.0
+        );
+        godot_print!(
+            "AlgoTiming step UpdateNeighbors: {:.3} ms",
+            self.neighbors.as_secs_f64() * 1000.0
+        );
+        godot_print!(
+            "AlgoTiming step LayersUpdate: {:.3} ms",
+            self.layers.as_secs_f64() * 1000.0
+        );
+        godot_print!(
+            "AlgoTiming step FinalOutput: {:.3} ms",
+            self.final_output.as_secs_f64() * 1000.0
+        );
+
+        let mut slowest = ("MarkTrisToDivide", self.mark);
+        if self.divide > slowest.1 {
+            slowest = ("Divide", self.divide);
+        }
+        if self.merge > slowest.1 {
+            slowest = ("Merge", self.merge);
+        }
+        if self.compact > slowest.1 {
+            slowest = ("Compact", self.compact);
+        }
+        if self.neighbors > slowest.1 {
+            slowest = ("UpdateNeighbors", self.neighbors);
+        }
+        if self.layers > slowest.1 {
+            slowest = ("LayersUpdate", self.layers);
+        }
+        if self.final_output > slowest.1 {
+            slowest = ("FinalOutput", self.final_output);
+        }
+
+        godot_print!(
+            "AlgoTiming slowest: {} ({:.3} ms)",
+            slowest.0,
+            slowest.1.as_secs_f64() * 1000.0
+        );
+    }
 }
 
 /// Orchestrates the adaptive LOD subdivision loop.
@@ -71,6 +148,19 @@ impl CesRunAlgo {
         layers: &mut [Box<dyn CesLayer>],
         skip_auto_division_marking: bool,
     ) {
+        let total_start = Instant::now();
+        let mut timings = AlgoTimingTotals {
+            total: Duration::ZERO,
+            mark: Duration::ZERO,
+            divide: Duration::ZERO,
+            merge: Duration::ZERO,
+            compact: Duration::ZERO,
+            neighbors: Duration::ZERO,
+            layers: Duration::ZERO,
+            final_output: Duration::ZERO,
+            iterations: 0,
+        };
+
         if self.state.is_none() {
             self.state = Some(initial_state::create_core_state(rd));
             Self::layers_update(rd, self.state.as_ref().unwrap(), layers, config.radius);
@@ -84,8 +174,10 @@ impl CesRunAlgo {
 
         while n_tris_added > 0 || n_tris_merged > 0 || first_run {
             first_run = false;
+            timings.iterations += 1;
 
             if !skip_auto_division_marking {
+                let mark_start = Instant::now();
                 mark_tris::flag_large_tris_to_divide(
                     rd,
                     state,
@@ -94,14 +186,19 @@ impl CesRunAlgo {
                     config.radius,
                     config.triangle_screen_size,
                 );
+                timings.mark += mark_start.elapsed();
             }
 
+            let divide_start = Instant::now();
             n_tris_added = div_lod::make_div(rd, state, config.precise_normals);
+            timings.divide += divide_start.elapsed();
             if n_tris_added > 0 && config.show_debug_messages {
                 godot_print!("Divided {} triangles", n_tris_added / 4);
             }
 
+            let merge_start = Instant::now();
             n_tris_merged = merge_lod::make_merge(rd, state);
+            timings.merge += merge_start.elapsed();
             if n_tris_merged > 0 && config.show_debug_messages {
                 godot_print!(
                     "Merged {} triangle(s) (removed {} child triangles)",
@@ -114,21 +211,34 @@ impl CesRunAlgo {
                 if config.show_debug_messages {
                     godot_print!("Removing free space inside buffers");
                 }
+                let compact_start = Instant::now();
                 compact_buffers::compact(rd, state);
+                timings.compact += compact_start.elapsed();
             }
 
             if n_tris_added > 0 || n_tris_merged > 0 {
+                let neighbors_start = Instant::now();
                 update_neighbors::update_neighbors(rd, state);
+                timings.neighbors += neighbors_start.elapsed();
             }
 
+            let layers_start = Instant::now();
             Self::layers_update(rd, state, layers, config.radius);
+            timings.layers += layers_start.elapsed();
         }
 
+        let final_start = Instant::now();
         let final_output = final_state::create_final_output(rd, state, config.low_poly_look);
+        timings.final_output += final_start.elapsed();
         self.pos = final_output.pos;
         self.normals = final_output.normals;
         self.triangles = final_output.tris;
         self.sim_value = final_output.color;
+
+        timings.total = total_start.elapsed();
+        if config.show_debug_messages {
+            timings.print_summary();
+        }
     }
 
     /// Frees all GPU resources held by the state.

--- a/rust/src/algo/run_algo.rs
+++ b/rust/src/algo/run_algo.rs
@@ -1,5 +1,6 @@
 use godot::builtin::Vector3;
 use godot::classes::RenderingDevice;
+use godot::obj::Gd;
 use godot::prelude::godot_print;
 use std::time::{Duration, Instant};
 
@@ -122,7 +123,7 @@ impl CesRunAlgo {
 
     /// Runs all layers' state initialization and position update.
     fn layers_update(
-        rd: &mut RenderingDevice,
+        rd: &mut Gd<RenderingDevice>,
         state: &CesState,
         layers: &mut [Box<dyn CesLayer>],
         radius: f32,
@@ -142,7 +143,7 @@ impl CesRunAlgo {
     /// Mirrors C# `CesRunAlgo.UpdateTriangleGraph`.
     pub fn update_triangle_graph(
         &mut self,
-        rd: &mut RenderingDevice,
+        rd: &mut Gd<RenderingDevice>,
         cam_local: Vector3,
         config: &RunAlgoConfig,
         layers: &mut [Box<dyn CesLayer>],
@@ -242,7 +243,7 @@ impl CesRunAlgo {
     }
 
     /// Frees all GPU resources held by the state.
-    pub fn dispose(&mut self, rd: &mut RenderingDevice) {
+    pub fn dispose(&mut self, rd: &mut Gd<RenderingDevice>) {
         if let Some(ref state) = self.state {
             state.dispose(rd);
         }

--- a/rust/src/algo/update_neighbors.rs
+++ b/rust/src/algo/update_neighbors.rs
@@ -1,0 +1,32 @@
+use godot::classes::RenderingDevice;
+
+use crate::buffer_info::BufferInfo;
+use crate::compute_utils;
+use crate::state::CesState;
+
+const SHADER_PATH: &str = "res://addons/celestial_sim_rust/shaders/UpdateNeighbors.slang";
+
+/// Dispatches the UpdateNeighbors shader. Mirrors C# `CesUpdateNeighbors.UpdateNeighbors()`.
+pub fn update_neighbors(rd: &mut RenderingDevice, state: &CesState) {
+    let n_tris_buf = compute_utils::create_uniform_buffer(rd, &state.n_tris);
+
+    let buffers: Vec<&BufferInfo> = vec![
+        &state.v_pos,          // 0
+        &state.t_abc,          // 1
+        &state.t_neight_ab,    // 2
+        &state.t_neight_bc,    // 3
+        &state.t_neight_ca,    // 4
+        &state.t_parent,       // 5
+        &state.t_divided,      // 6
+        &state.t_lv,           // 7
+        &state.t_a_t,          // 8
+        &state.t_b_t,          // 9
+        &state.t_c_t,          // 10
+        &state.t_center_t,     // 11
+        &n_tris_buf,           // 12
+    ];
+
+    compute_utils::dispatch_shader(rd, SHADER_PATH, &buffers, state.n_tris);
+
+    rd.free_rid(n_tris_buf.rid);
+}

--- a/rust/src/algo/update_neighbors.rs
+++ b/rust/src/algo/update_neighbors.rs
@@ -1,4 +1,5 @@
 use godot::classes::RenderingDevice;
+use godot::obj::Gd;
 
 use crate::buffer_info::BufferInfo;
 use crate::compute_utils;
@@ -7,7 +8,7 @@ use crate::state::CesState;
 const SHADER_PATH: &str = "res://addons/celestial_sim_rust/shaders/UpdateNeighbors.slang";
 
 /// Dispatches the UpdateNeighbors shader. Mirrors C# `CesUpdateNeighbors.UpdateNeighbors()`.
-pub fn update_neighbors(rd: &mut RenderingDevice, state: &CesState) {
+pub fn update_neighbors(rd: &mut Gd<RenderingDevice>, state: &CesState) {
     let n_tris_buf = compute_utils::create_uniform_buffer(rd, &state.n_tris);
 
     let buffers: Vec<&BufferInfo> = vec![
@@ -28,5 +29,5 @@ pub fn update_neighbors(rd: &mut RenderingDevice, state: &CesState) {
 
     compute_utils::dispatch_shader(rd, SHADER_PATH, &buffers, state.n_tris);
 
-    rd.free_rid(n_tris_buf.rid);
+    compute_utils::free_rid_on_render_thread(rd, n_tris_buf.rid);
 }

--- a/rust/src/algo/update_neighbors.rs
+++ b/rust/src/algo/update_neighbors.rs
@@ -2,32 +2,40 @@ use godot::classes::RenderingDevice;
 use godot::obj::Gd;
 
 use crate::buffer_info::BufferInfo;
-use crate::compute_utils;
+use crate::compute_utils::ComputePipeline;
 use crate::state::CesState;
 
 const SHADER_PATH: &str = "res://addons/celestial_sim_rust/shaders/UpdateNeighbors.slang";
 
-/// Dispatches the UpdateNeighbors shader. Mirrors C# `CesUpdateNeighbors.UpdateNeighbors()`.
-pub fn update_neighbors(rd: &mut Gd<RenderingDevice>, state: &CesState) {
-    let n_tris_buf = compute_utils::create_uniform_buffer(rd, &state.n_tris);
+pub struct UpdateNeighborsShader {
+    pipeline: ComputePipeline,
+}
 
-    let buffers: Vec<&BufferInfo> = vec![
-        &state.v_pos,          // 0
-        &state.t_abc,          // 1
-        &state.t_neight_ab,    // 2
-        &state.t_neight_bc,    // 3
-        &state.t_neight_ca,    // 4
-        &state.t_parent,       // 5
-        &state.t_divided,      // 6
-        &state.t_lv,           // 7
-        &state.t_a_t,          // 8
-        &state.t_b_t,          // 9
-        &state.t_c_t,          // 10
-        &state.t_center_t,     // 11
-        &n_tris_buf,           // 12
-    ];
+impl UpdateNeighborsShader {
+    pub fn new(rd: &mut Gd<RenderingDevice>) -> Self {
+        Self {
+            pipeline: ComputePipeline::new(rd, SHADER_PATH),
+        }
+    }
 
-    compute_utils::dispatch_shader(rd, SHADER_PATH, &buffers, state.n_tris);
+    /// Dispatches the UpdateNeighbors shader. Mirrors C# `CesUpdateNeighbors.UpdateNeighbors()`.
+    pub fn update_neighbors(&self, rd: &mut Gd<RenderingDevice>, state: &CesState) {
+        let buffers: Vec<&BufferInfo> = vec![
+            &state.v_pos,       // 0
+            &state.t_abc,       // 1
+            &state.t_neight_ab, // 2
+            &state.t_neight_bc, // 3
+            &state.t_neight_ca, // 4
+            &state.t_parent,    // 5
+            &state.t_divided,   // 6
+            &state.t_lv,        // 7
+            &state.t_a_t,       // 8
+            &state.t_b_t,       // 9
+            &state.t_c_t,       // 10
+            &state.t_center_t,  // 11
+            &state.u_n_tris,    // 12
+        ];
 
-    compute_utils::free_rid_on_render_thread(rd, n_tris_buf.rid);
+        self.pipeline.dispatch(rd, &buffers, state.n_tris);
+    }
 }

--- a/rust/src/buffer_info.rs
+++ b/rust/src/buffer_info.rs
@@ -3,6 +3,8 @@ use godot::classes::{RdUniform, RenderingDevice};
 use godot::obj::{Gd, NewGd};
 use godot::prelude::Rid;
 
+use crate::compute_utils;
+
 /// Type of GPU buffer.
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub enum BufferType {
@@ -64,7 +66,7 @@ impl BufferInfo {
     /// If `filled_size + bytes_to_extend` fits within `max_size` (and the buffer
     /// isn't more than 2x the needed size), just bumps `filled_size`.
     /// Otherwise allocates a new buffer, copies data, and frees the old one.
-    pub fn extend_buffer(&mut self, rd: &mut RenderingDevice, bytes_to_extend: u32) {
+    pub fn extend_buffer(&mut self, rd: &mut Gd<RenderingDevice>, bytes_to_extend: u32) {
         let desired_size = self.filled_size + bytes_to_extend;
 
         // Reuse existing buffer if it fits and isn't oversized (>2x)
@@ -73,24 +75,24 @@ impl BufferInfo {
             return;
         }
 
-        // Allocate a new buffer
+        // Allocate a new buffer (does not need render thread)
         let new_rid = rd.storage_buffer_create(desired_size);
         assert!(
             new_rid.is_valid(),
             "Failed to create new storage buffer during extend"
         );
 
-        // Clear the new buffer to prevent garbage data in uninitialized region
-        rd.buffer_clear(new_rid, 0, desired_size);
-
         let old_rid = self.rid;
         let old_filled = self.filled_size;
 
-        // Copy existing data into new buffer
-        rd.buffer_copy(old_rid, new_rid, 0, 0, old_filled);
-
-        // Free old buffer
-        rd.free_rid(old_rid);
+        // Clear, copy, and free on the render thread
+        let rd_send = compute_utils::RdSend(rd.clone());
+        compute_utils::on_render_thread(move || {
+            let mut rd = rd_send;
+            rd.0.buffer_clear(new_rid, 0, desired_size);
+            rd.0.buffer_copy(old_rid, new_rid, 0, 0, old_filled);
+            rd.0.free_rid(old_rid);
+        });
 
         // Update self
         self.rid = new_rid;

--- a/rust/src/celestial.rs
+++ b/rust/src/celestial.rs
@@ -1,0 +1,300 @@
+use godot::builtin::{
+    PackedInt32Array, PackedVector2Array, PackedVector3Array, Transform3D, Variant, Vector2,
+    Vector3,
+};
+use godot::classes::mesh::ArrayType;
+use godot::classes::mesh::PrimitiveType;
+use godot::classes::{
+    ArrayMesh, Camera3D, ConcavePolygonShape3D, CollisionShape3D, INode3D, Node3D,
+    RenderingDevice, RenderingServer, Shader, ShaderMaterial, StaticBody3D,
+};
+use godot::prelude::*;
+
+use crate::algo::run_algo::{CesRunAlgo, RunAlgoConfig};
+use crate::layers::sphere_terrain::CesSphereTerrain;
+use crate::layers::CesLayer;
+
+#[derive(GodotClass)]
+#[class(base = Node3D)]
+pub struct CesCelestialRust {
+    base: Base<Node3D>,
+
+    #[export]
+    gameplay_camera: Option<Gd<Camera3D>>,
+
+    #[export]
+    radius: f32,
+
+    #[export]
+    subdivisions: u32,
+
+    #[export]
+    triangle_screen_size: f32,
+
+    #[export]
+    low_poly_look: bool,
+
+    #[export]
+    precise_normals: bool,
+
+    #[export]
+    generate_collision: bool,
+
+    #[export]
+    show_debug_messages: bool,
+
+    #[export]
+    seed: i32,
+
+    #[export]
+    shader: Option<Gd<Shader>>,
+
+    instance: Rid,
+    mesh: Option<Gd<ArrayMesh>>,
+    rd: Option<Gd<RenderingDevice>>,
+    graph_generator: Option<CesRunAlgo>,
+    layers: Vec<Box<dyn CesLayer>>,
+    last_cam_position: Vector3,
+    last_obj_transform: Transform3D,
+    values_updated: bool,
+    is_shutting_down: bool,
+}
+
+#[godot_api]
+impl INode3D for CesCelestialRust {
+    fn init(base: Base<Node3D>) -> Self {
+        Self {
+            base,
+            gameplay_camera: None,
+            radius: 1.0,
+            subdivisions: 3,
+            triangle_screen_size: 0.1,
+            low_poly_look: true,
+            precise_normals: true,
+            generate_collision: false,
+            show_debug_messages: false,
+            seed: 0,
+            shader: None,
+            instance: Rid::Invalid,
+            mesh: None,
+            rd: None,
+            graph_generator: None,
+            layers: Vec::new(),
+            last_cam_position: Vector3::ZERO,
+            last_obj_transform: Transform3D::IDENTITY,
+            values_updated: false,
+            is_shutting_down: false,
+        }
+    }
+
+    fn enter_tree(&mut self) {
+        let mut rs = RenderingServer::singleton();
+        self.instance = rs.instance_create();
+
+        let scenario = self.base().get_world_3d().unwrap().get_scenario();
+        rs.instance_set_scenario(self.instance, scenario);
+
+        let mesh = ArrayMesh::new_gd();
+        rs.instance_set_base(self.instance, mesh.get_rid());
+        self.mesh = Some(mesh);
+
+        self.rd = Some(rs.create_local_rendering_device().unwrap());
+    }
+
+    fn ready(&mut self) {
+        self.add_subnodes();
+        self.layers = vec![Box::new(CesSphereTerrain::new())];
+    }
+
+    fn process(&mut self, _delta: f64) {
+        if self.is_shutting_down {
+            return;
+        }
+
+        let global_transform = self.base().get_global_transform();
+        let mut rs = RenderingServer::singleton();
+        rs.instance_set_transform(self.instance, global_transform);
+
+        let cam = self.get_camera();
+        if cam.is_none() {
+            return;
+        }
+        let cam = cam.unwrap();
+
+        let cam_pos = cam.get_global_position();
+        let has_changed = global_transform != self.last_obj_transform
+            || cam_pos != self.last_cam_position
+            || self.values_updated;
+
+        if !has_changed {
+            return;
+        }
+
+        self.last_obj_transform = global_transform;
+        self.last_cam_position = cam_pos;
+        self.values_updated = false;
+
+        let cam_local = global_transform.affine_inverse() * cam_pos;
+        self.gen_mesh(cam_local);
+    }
+
+    fn exit_tree(&mut self) {
+        self.is_shutting_down = true;
+
+        if let Some(ref mut rd) = self.rd {
+            if let Some(ref mut gen) = self.graph_generator {
+                gen.dispose(rd);
+            }
+        }
+        self.graph_generator = None;
+
+        let mut rs = RenderingServer::singleton();
+        if self.instance.is_valid() {
+            rs.free_rid(self.instance);
+            self.instance = Rid::Invalid;
+        }
+        if let Some(ref mesh) = self.mesh {
+            rs.free_rid(mesh.get_rid());
+        }
+        self.mesh = None;
+        self.rd = None;
+        self.layers.clear();
+    }
+}
+
+impl CesCelestialRust {
+    fn get_camera(&self) -> Option<Gd<Camera3D>> {
+        if let Some(ref cam) = self.gameplay_camera {
+            return Some(cam.clone());
+        }
+        self.base().get_viewport().and_then(|vp| vp.get_camera_3d())
+    }
+
+    fn gen_mesh(&mut self, cam_local: Vector3) {
+        let config = RunAlgoConfig {
+            subdivisions: self.subdivisions,
+            radius: self.radius,
+            triangle_screen_size: self.triangle_screen_size,
+            precise_normals: self.precise_normals,
+            low_poly_look: self.low_poly_look,
+            show_debug_messages: self.show_debug_messages,
+        };
+
+        if self.graph_generator.is_none() {
+            self.graph_generator = Some(CesRunAlgo::new());
+        }
+
+        let rd = self.rd.as_mut().unwrap();
+        let gen = self.graph_generator.as_mut().unwrap();
+        gen.update_triangle_graph(rd, cam_local, &config, &mut self.layers, false);
+
+        if gen.pos.is_empty() || gen.triangles.is_empty() {
+            return;
+        }
+
+        // Build packed arrays
+        let mut packed_verts = PackedVector3Array::new();
+        for v in gen.pos.iter() {
+            packed_verts.push(*v);
+        }
+
+        let mut packed_normals = PackedVector3Array::new();
+        for n in gen.normals.iter() {
+            packed_normals.push(*n);
+        }
+
+        let mut packed_indices = PackedInt32Array::new();
+        for idx in gen.triangles.iter() {
+            packed_indices.push(*idx);
+        }
+
+        let mut packed_uvs = PackedVector2Array::new();
+        for uv in gen.sim_value.iter() {
+            packed_uvs.push(Vector2::new(uv[0], uv[1]));
+        }
+
+        // Build surface array
+        let mut surface_array = varray![];
+        surface_array.resize(ArrayType::MAX.ord() as usize, &Variant::nil());
+        surface_array.set(ArrayType::VERTEX.ord() as usize, &packed_verts.to_variant());
+        surface_array.set(ArrayType::NORMAL.ord() as usize, &packed_normals.to_variant());
+        surface_array.set(ArrayType::INDEX.ord() as usize, &packed_indices.to_variant());
+        surface_array.set(ArrayType::TEX_UV.ord() as usize, &packed_uvs.to_variant());
+
+        let mut new_mesh = ArrayMesh::new_gd();
+        new_mesh.add_surface_from_arrays(PrimitiveType::TRIANGLES, &surface_array);
+
+        if let Some(ref shader) = self.shader {
+            let mut material = ShaderMaterial::new_gd();
+            material.set_shader(shader);
+            material.set_shader_parameter("radius", &self.radius.to_variant());
+            new_mesh.surface_set_material(0, &material);
+        }
+
+        // Swap mesh on rendering server
+        let mut rs = RenderingServer::singleton();
+        rs.instance_set_base(self.instance, new_mesh.get_rid());
+
+        if let Some(ref old_mesh) = self.mesh {
+            rs.free_rid(old_mesh.get_rid());
+        }
+        self.mesh = Some(new_mesh);
+
+        if self.show_debug_messages {
+            godot_print!("Mesh triangles: {}", gen.triangles.len() / 3);
+        }
+
+        // Collision
+        if self.generate_collision {
+            self.update_collision();
+        }
+    }
+
+    fn add_subnodes(&mut self) {
+        // StaticBody3D with CollisionShape3D
+        let mut static_body = StaticBody3D::new_alloc();
+        static_body.set_name("StaticBody3D");
+
+        let mut collision_shape = CollisionShape3D::new_alloc();
+        collision_shape.set_name("CollisionShape3D");
+        let shape = ConcavePolygonShape3D::new_gd();
+        collision_shape.set_shape(&shape);
+
+        static_body.add_child(&collision_shape);
+        self.base_mut().add_child(&static_body);
+    }
+
+    fn update_collision(&mut self) {
+        if let Some(mesh) = self.mesh.as_ref() {
+            let shape = mesh.create_trimesh_shape();
+            if let Some(shape) = shape {
+                let mut collision = self
+                    .base()
+                    .get_node_as::<CollisionShape3D>("StaticBody3D/CollisionShape3D");
+                collision.set_shape(&shape);
+            }
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use crate::algo::run_algo::RunAlgoConfig;
+
+    #[test]
+    fn test_default_config() {
+        let config = RunAlgoConfig {
+            subdivisions: 3,
+            radius: 1.0,
+            triangle_screen_size: 0.1,
+            precise_normals: true,
+            low_poly_look: false,
+            show_debug_messages: false,
+        };
+        assert_eq!(config.subdivisions, 3);
+        assert!((config.radius - 1.0).abs() < f32::EPSILON);
+        assert!((config.triangle_screen_size - 0.1).abs() < f32::EPSILON);
+        assert!(config.precise_normals);
+        assert!(!config.low_poly_look);
+    }
+}

--- a/rust/src/celestial.rs
+++ b/rust/src/celestial.rs
@@ -276,6 +276,17 @@ impl INode3D for CesCelestialRust {
     fn exit_tree(&mut self) {
         self.is_shutting_down = true;
 
+        // Free the RS instance and mesh FIRST so the planet disappears immediately
+        let mut rs = RenderingServer::singleton();
+        if self.instance.is_valid() {
+            rs.free_rid(self.instance);
+            self.instance = Rid::Invalid;
+        }
+        if let Some(ref mesh) = self.mesh {
+            rs.free_rid(mesh.get_rid());
+        }
+        self.mesh = None;
+
         // Drop the sender to signal the worker thread to exit
         drop(self.work_tx.take());
         self.result_rx = None;
@@ -302,16 +313,6 @@ impl INode3D for CesCelestialRust {
                 }
             }
         }
-
-        let mut rs = RenderingServer::singleton();
-        if self.instance.is_valid() {
-            rs.free_rid(self.instance);
-            self.instance = Rid::Invalid;
-        }
-        if let Some(ref mesh) = self.mesh {
-            rs.free_rid(mesh.get_rid());
-        }
-        self.mesh = None;
     }
 }
 

--- a/rust/src/celestial.rs
+++ b/rust/src/celestial.rs
@@ -9,6 +9,7 @@ use godot::classes::{
     RenderingDevice, RenderingServer, Shader, ShaderMaterial, StaticBody3D,
 };
 use godot::prelude::*;
+use std::time::Instant;
 
 use crate::algo::run_algo::{CesRunAlgo, RunAlgoConfig};
 use crate::layers::sphere_terrain::CesSphereTerrain;
@@ -83,7 +84,7 @@ impl INode3D for CesCelestialRust {
             subdivisions: 3,
             triangle_screen_size: 0.1,
             low_poly_look: true,
-            precise_normals: true,
+            precise_normals: false,
             generate_collision: false,
             show_debug_messages: false,
             seed: 0,
@@ -100,7 +101,7 @@ impl INode3D for CesCelestialRust {
                 subdivisions: 3,
                 triangle_screen_size: 0.1,
                 low_poly_look: true,
-                precise_normals: true,
+                precise_normals: false,
                 generate_collision: false,
                 show_debug_messages: false,
                 seed: 0,
@@ -225,6 +226,7 @@ impl CesCelestialRust {
     }
 
     fn gen_mesh(&mut self, cam_local: Vector3) {
+        let total_start = Instant::now();
         let config = RunAlgoConfig {
             subdivisions: self.subdivisions,
             radius: self.radius,
@@ -301,12 +303,16 @@ impl CesCelestialRust {
         self.mesh = Some(new_mesh);
 
         if self.show_debug_messages {
-            godot_print!("Mesh triangles: {}", gen.triangles.len() / 3);
+            godot_print!("Mesh Triangles: {}", gen.triangles.len() / 3);
         }
 
         // Collision
         if self.generate_collision {
             self.update_collision();
+        }
+
+        if self.show_debug_messages {
+            godot_print!("Completed in {} ms", total_start.elapsed().as_millis());
         }
     }
 

--- a/rust/src/celestial.rs
+++ b/rust/src/celestial.rs
@@ -12,6 +12,8 @@ use godot::classes::{
     RenderingDevice, RenderingServer, Shader, ShaderMaterial, StaticBody3D,
 };
 use godot::prelude::*;
+use std::thread;
+use std::time::{Duration, Instant};
 
 #[derive(Clone, Copy, PartialEq)]
 struct SettingsSnapshot {
@@ -46,6 +48,34 @@ struct WorkerState {
     rd: Gd<RenderingDevice>,
     graph_generator: Option<CesRunAlgo>,
     layers: Vec<Box<dyn CesLayer>>,
+}
+
+struct ScopedTimer {
+    label: &'static str,
+    start: Instant,
+    enabled: bool,
+}
+
+impl ScopedTimer {
+    fn new(label: &'static str, enabled: bool) -> Self {
+        Self {
+            label,
+            start: Instant::now(),
+            enabled,
+        }
+    }
+}
+
+impl Drop for ScopedTimer {
+    fn drop(&mut self) {
+        if self.enabled {
+            godot_print!(
+                "{} took {:.3} ms",
+                self.label,
+                self.start.elapsed().as_secs_f64() * 1000.0
+            );
+        }
+    }
 }
 
 // SAFETY: WorkerState contains a local RenderingDevice created via
@@ -83,6 +113,12 @@ pub struct CesCelestialRust {
     show_debug_messages: bool,
 
     #[export]
+    show_process_timing: bool,
+
+    #[export]
+    simulated_process_delay_ms: u32,
+
+    #[export]
     seed: i32,
 
     #[export]
@@ -115,6 +151,8 @@ impl INode3D for CesCelestialRust {
             precise_normals: false,
             generate_collision: false,
             show_debug_messages: false,
+            show_process_timing: false,
+            simulated_process_delay_ms: 0,
             seed: 0,
             shader: None,
             instance: Rid::Invalid,
@@ -168,17 +206,28 @@ impl INode3D for CesCelestialRust {
             return;
         }
 
-        let global_transform = self.base().get_global_transform();
-        let mut rs = RenderingServer::singleton();
-        rs.instance_set_transform(self.instance, global_transform);
-
+        if self.simulated_process_delay_ms > 0 {
+            thread::sleep(Duration::from_millis(
+                self.simulated_process_delay_ms as u64,
+            ));
+        }
+        let mut show_timer = false;
         // 1. Check for completed results (non-blocking)
         if let Some(ref result_rx) = self.result_rx {
             if let Ok(result) = result_rx.try_recv() {
                 self.gen_mesh_running = false;
                 self.apply_mesh_result(result);
+                show_timer = self.show_process_timing; // Show timing when we get a result
             }
         }
+
+        let _process_timer =
+            ScopedTimer::new("CesCelestialRust::process", show_timer);
+
+
+        let global_transform = self.base().get_global_transform();
+        let mut rs = RenderingServer::singleton();
+        rs.instance_set_transform(self.instance, global_transform);
 
         // 2. Check if we need new work
         let cam = self.get_camera();
@@ -305,25 +354,21 @@ impl CesCelestialRust {
             return;
         }
 
-        let mut packed_verts = PackedVector3Array::new();
-        for v in result.pos.iter() {
-            packed_verts.push(*v);
-        }
+        let MeshResult {
+            pos,
+            normals,
+            triangles,
+            sim_value,
+        } = result;
+        let triangle_count = triangles.len() / 3;
 
-        let mut packed_normals = PackedVector3Array::new();
-        for n in result.normals.iter() {
-            packed_normals.push(*n);
-        }
-
-        let mut packed_indices = PackedInt32Array::new();
-        for idx in result.triangles.iter() {
-            packed_indices.push(*idx);
-        }
-
-        let mut packed_uvs = PackedVector2Array::new();
-        for uv in result.sim_value.iter() {
-            packed_uvs.push(Vector2::new(uv[0], uv[1]));
-        }
+        let packed_verts = PackedVector3Array::from(pos);
+        let packed_normals = PackedVector3Array::from(normals);
+        let packed_indices = PackedInt32Array::from(triangles);
+        let packed_uvs: PackedVector2Array = sim_value
+            .into_iter()
+            .map(|uv| Vector2::new(uv[0], uv[1]))
+            .collect();
 
         let mut surface_array = varray![];
         surface_array.resize(ArrayType::MAX.ord() as usize, &Variant::nil());
@@ -357,7 +402,7 @@ impl CesCelestialRust {
         self.mesh = Some(new_mesh);
 
         if self.show_debug_messages {
-            godot_print!("Mesh Triangles: {}", result.triangles.len() / 3);
+            godot_print!("Mesh Triangles: {}", triangle_count);
         }
 
         if self.generate_collision {

--- a/rust/src/celestial.rs
+++ b/rust/src/celestial.rs
@@ -1,3 +1,6 @@
+use crate::algo::run_algo::{CesRunAlgo, RunAlgoConfig};
+use crate::layers::sphere_terrain::CesSphereTerrain;
+use crate::layers::CesLayer;
 use godot::builtin::{
     PackedInt32Array, PackedVector2Array, PackedVector3Array, Transform3D, Variant, Vector2,
     Vector3,
@@ -9,11 +12,6 @@ use godot::classes::{
     RenderingDevice, RenderingServer, Shader, ShaderMaterial, StaticBody3D,
 };
 use godot::prelude::*;
-use std::time::Instant;
-
-use crate::algo::run_algo::{CesRunAlgo, RunAlgoConfig};
-use crate::layers::sphere_terrain::CesSphereTerrain;
-use crate::layers::CesLayer;
 
 #[derive(Clone, Copy, PartialEq)]
 struct SettingsSnapshot {
@@ -26,6 +24,34 @@ struct SettingsSnapshot {
     show_debug_messages: bool,
     seed: i32,
 }
+
+struct MeshResult {
+    pos: Vec<Vector3>,
+    normals: Vec<Vector3>,
+    triangles: Vec<i32>,
+    sim_value: Vec<[f32; 2]>,
+}
+
+#[derive(Clone)]
+struct WorkerConfig {
+    subdivisions: u32,
+    radius: f32,
+    triangle_screen_size: f32,
+    precise_normals: bool,
+    low_poly_look: bool,
+    show_debug_messages: bool,
+}
+
+struct WorkerState {
+    rd: Gd<RenderingDevice>,
+    graph_generator: Option<CesRunAlgo>,
+    layers: Vec<Box<dyn CesLayer>>,
+}
+
+// SAFETY: WorkerState contains a local RenderingDevice created via
+// RenderingServer::create_local_rendering_device(). Local RDs are independent
+// and do not share state with the main renderer, making cross-thread use safe.
+unsafe impl Send for WorkerState {}
 
 #[derive(GodotClass)]
 #[class(tool, base = Node3D)]
@@ -64,9 +90,11 @@ pub struct CesCelestialRust {
 
     instance: Rid,
     mesh: Option<Gd<ArrayMesh>>,
-    rd: Option<Gd<RenderingDevice>>,
-    graph_generator: Option<CesRunAlgo>,
-    layers: Vec<Box<dyn CesLayer>>,
+    // Threading fields
+    work_tx: Option<std::sync::mpsc::Sender<(Vector3, WorkerConfig)>>,
+    result_rx: Option<std::sync::mpsc::Receiver<MeshResult>>,
+    worker_handle: Option<std::thread::JoinHandle<WorkerState>>,
+    gen_mesh_running: bool,
     last_cam_position: Vector3,
     last_obj_transform: Transform3D,
     last_settings: SettingsSnapshot,
@@ -91,9 +119,10 @@ impl INode3D for CesCelestialRust {
             shader: None,
             instance: Rid::Invalid,
             mesh: None,
-            rd: None,
-            graph_generator: None,
-            layers: Vec::new(),
+            work_tx: None,
+            result_rx: None,
+            worker_handle: None,
+            gen_mesh_running: false,
             last_cam_position: Vector3::ZERO,
             last_obj_transform: Transform3D::IDENTITY,
             last_settings: SettingsSnapshot {
@@ -122,12 +151,14 @@ impl INode3D for CesCelestialRust {
         rs.instance_set_base(self.instance, mesh.get_rid());
         self.mesh = Some(mesh);
 
-        self.rd = Some(rs.create_local_rendering_device().unwrap());
+        // RD is now owned by the worker thread
+        let rd = rs.create_local_rendering_device().unwrap();
+        let layers: Vec<Box<dyn CesLayer>> = vec![Box::new(CesSphereTerrain::new())];
+        self.spawn_worker(rd, layers);
     }
 
     fn ready(&mut self) {
         self.add_subnodes();
-        self.layers = vec![Box::new(CesSphereTerrain::new())];
         self.last_settings = self.current_settings();
         self.values_updated = true;
     }
@@ -141,12 +172,20 @@ impl INode3D for CesCelestialRust {
         let mut rs = RenderingServer::singleton();
         rs.instance_set_transform(self.instance, global_transform);
 
+        // 1. Check for completed results (non-blocking)
+        if let Some(ref result_rx) = self.result_rx {
+            if let Ok(result) = result_rx.try_recv() {
+                self.gen_mesh_running = false;
+                self.apply_mesh_result(result);
+            }
+        }
+
+        // 2. Check if we need new work
         let cam = self.get_camera();
         if cam.is_none() {
             return;
         }
         let cam = cam.unwrap();
-
         let cam_pos = cam.get_global_position();
         let current_settings = self.current_settings();
         let has_changed = global_transform != self.last_obj_transform
@@ -154,28 +193,66 @@ impl INode3D for CesCelestialRust {
             || current_settings != self.last_settings
             || self.values_updated;
 
-        if !has_changed {
+        if !has_changed || self.gen_mesh_running {
             return;
         }
 
+        // 3. Update tracking state and dispatch work
         self.last_obj_transform = global_transform;
         self.last_cam_position = cam_pos;
         self.last_settings = current_settings;
         self.values_updated = false;
 
         let cam_local = global_transform.affine_inverse() * cam_pos;
-        self.gen_mesh(cam_local);
+        let config = WorkerConfig {
+            subdivisions: self.subdivisions,
+            radius: self.radius,
+            triangle_screen_size: self.triangle_screen_size,
+            precise_normals: self.precise_normals,
+            low_poly_look: self.low_poly_look,
+            show_debug_messages: self.show_debug_messages,
+        };
+
+        if let Some(ref work_tx) = self.work_tx {
+            if work_tx.send((cam_local, config)).is_ok() {
+                self.gen_mesh_running = true;
+            } else {
+                godot_print!("[CesCelestialRust] ERROR: Failed to send work to worker thread");
+            }
+        } else {
+            godot_print!("[CesCelestialRust] ERROR: work_tx is None, worker not spawned");
+        }
     }
 
     fn exit_tree(&mut self) {
         self.is_shutting_down = true;
 
-        if let Some(ref mut rd) = self.rd {
-            if let Some(ref mut gen) = self.graph_generator {
-                gen.dispose(rd);
+        // Drop the sender to signal the worker thread to exit
+        drop(self.work_tx.take());
+        self.result_rx = None;
+
+        // Join the worker thread with a timeout to recover the RenderingDevice.
+        // The worker should be idle on recv() which will return Err immediately
+        // once work_tx is dropped.
+        if let Some(handle) = self.worker_handle.take() {
+            let (done_tx, done_rx) = std::sync::mpsc::channel();
+            std::thread::spawn(move || {
+                let worker = handle.join();
+                let _ = done_tx.send(worker);
+            });
+            match done_rx.recv_timeout(std::time::Duration::from_secs(2)) {
+                Ok(Ok(mut worker)) => {
+                    // Free the local RenderingDevice explicitly before engine teardown
+                    if let Some(ref mut gen) = worker.graph_generator {
+                        gen.dispose(&mut worker.rd);
+                    }
+                    worker.rd.free();
+                }
+                _ => {
+                    godot_warn!("Worker thread did not shut down in time; GPU resources may leak");
+                }
             }
         }
-        self.graph_generator = None;
 
         let mut rs = RenderingServer::singleton();
         if self.instance.is_valid() {
@@ -186,8 +263,6 @@ impl INode3D for CesCelestialRust {
             rs.free_rid(mesh.get_rid());
         }
         self.mesh = None;
-        self.rd = None;
-        self.layers.clear();
     }
 }
 
@@ -225,51 +300,31 @@ impl CesCelestialRust {
         self.base().get_viewport().and_then(|vp| vp.get_camera_3d())
     }
 
-    fn gen_mesh(&mut self, cam_local: Vector3) {
-        let total_start = Instant::now();
-        let config = RunAlgoConfig {
-            subdivisions: self.subdivisions,
-            radius: self.radius,
-            triangle_screen_size: self.triangle_screen_size,
-            precise_normals: self.precise_normals,
-            low_poly_look: self.low_poly_look,
-            show_debug_messages: self.show_debug_messages,
-        };
-
-        if self.graph_generator.is_none() {
-            self.graph_generator = Some(CesRunAlgo::new());
-        }
-
-        let rd = self.rd.as_mut().unwrap();
-        let gen = self.graph_generator.as_mut().unwrap();
-        gen.update_triangle_graph(rd, cam_local, &config, &mut self.layers, false);
-
-        if gen.pos.is_empty() || gen.triangles.is_empty() {
+    fn apply_mesh_result(&mut self, result: MeshResult) {
+        if result.pos.is_empty() || result.triangles.is_empty() {
             return;
         }
 
-        // Build packed arrays
         let mut packed_verts = PackedVector3Array::new();
-        for v in gen.pos.iter() {
+        for v in result.pos.iter() {
             packed_verts.push(*v);
         }
 
         let mut packed_normals = PackedVector3Array::new();
-        for n in gen.normals.iter() {
+        for n in result.normals.iter() {
             packed_normals.push(*n);
         }
 
         let mut packed_indices = PackedInt32Array::new();
-        for idx in gen.triangles.iter() {
+        for idx in result.triangles.iter() {
             packed_indices.push(*idx);
         }
 
         let mut packed_uvs = PackedVector2Array::new();
-        for uv in gen.sim_value.iter() {
+        for uv in result.sim_value.iter() {
             packed_uvs.push(Vector2::new(uv[0], uv[1]));
         }
 
-        // Build surface array
         let mut surface_array = varray![];
         surface_array.resize(ArrayType::MAX.ord() as usize, &Variant::nil());
         surface_array.set(ArrayType::VERTEX.ord() as usize, &packed_verts.to_variant());
@@ -293,7 +348,6 @@ impl CesCelestialRust {
             new_mesh.surface_set_material(0, &material);
         }
 
-        // Swap mesh on rendering server
         let mut rs = RenderingServer::singleton();
         rs.instance_set_base(self.instance, new_mesh.get_rid());
 
@@ -303,16 +357,11 @@ impl CesCelestialRust {
         self.mesh = Some(new_mesh);
 
         if self.show_debug_messages {
-            godot_print!("Mesh Triangles: {}", gen.triangles.len() / 3);
+            godot_print!("Mesh Triangles: {}", result.triangles.len() / 3);
         }
 
-        // Collision
         if self.generate_collision {
             self.update_collision();
-        }
-
-        if self.show_debug_messages {
-            godot_print!("Completed in {} ms", total_start.elapsed().as_millis());
         }
     }
 
@@ -328,6 +377,73 @@ impl CesCelestialRust {
 
         static_body.add_child(&collision_shape);
         self.base_mut().add_child(&static_body);
+    }
+
+    /// Spawns the persistent worker thread. The worker owns the RenderingDevice,
+    /// RunAlgo, and layers. It waits for work requests and sends back MeshResults.
+    fn spawn_worker(&mut self, rd: Gd<RenderingDevice>, layers: Vec<Box<dyn CesLayer>>) {
+        let (work_tx, work_rx) = std::sync::mpsc::channel::<(Vector3, WorkerConfig)>();
+        let (result_tx, result_rx) = std::sync::mpsc::channel::<MeshResult>();
+
+        let mut worker = WorkerState {
+            rd,
+            graph_generator: None,
+            layers,
+        };
+
+        let handle = std::thread::spawn(move || {
+            while let Ok((cam_local, config)) = work_rx.recv() {
+                let algo_config = RunAlgoConfig {
+                    subdivisions: config.subdivisions,
+                    radius: config.radius,
+                    triangle_screen_size: config.triangle_screen_size,
+                    precise_normals: config.precise_normals,
+                    low_poly_look: config.low_poly_look,
+                    show_debug_messages: config.show_debug_messages,
+                };
+
+                if worker.graph_generator.is_none() {
+                    worker.graph_generator = Some(CesRunAlgo::new());
+                }
+
+                let gen = worker.graph_generator.as_mut().unwrap();
+                gen.update_triangle_graph(
+                    &mut worker.rd,
+                    cam_local,
+                    &algo_config,
+                    &mut worker.layers,
+                    false,
+                );
+
+                if gen.pos.is_empty() || gen.triangles.is_empty() {
+                    let _ = result_tx.send(MeshResult {
+                        pos: vec![],
+                        normals: vec![],
+                        triangles: vec![],
+                        sim_value: vec![],
+                    });
+                    continue;
+                }
+
+                let result = MeshResult {
+                    pos: gen.pos.clone(),
+                    normals: gen.normals.clone(),
+                    triangles: gen.triangles.clone(),
+                    sim_value: gen.sim_value.clone(),
+                };
+
+                if result_tx.send(result).is_err() {
+                    break; // Main thread dropped the receiver, exit
+                }
+            }
+
+            // Return worker state for cleanup
+            worker
+        });
+
+        self.work_tx = Some(work_tx);
+        self.result_rx = Some(result_rx);
+        self.worker_handle = Some(handle);
     }
 
     fn update_collision(&mut self) {
@@ -362,5 +478,23 @@ mod tests {
         assert!((config.triangle_screen_size - 0.1).abs() < f32::EPSILON);
         assert!(config.precise_normals);
         assert!(!config.low_poly_look);
+    }
+
+    #[test]
+    fn test_mesh_result_is_send() {
+        fn assert_send<T: Send>() {}
+        assert_send::<super::MeshResult>();
+    }
+
+    #[test]
+    fn test_worker_config_is_send() {
+        fn assert_send<T: Send>() {}
+        assert_send::<super::WorkerConfig>();
+    }
+
+    #[test]
+    fn test_worker_state_is_send() {
+        fn assert_send<T: Send>() {}
+        assert_send::<super::WorkerState>();
     }
 }

--- a/rust/src/celestial.rs
+++ b/rust/src/celestial.rs
@@ -5,7 +5,7 @@ use godot::builtin::{
 use godot::classes::mesh::ArrayType;
 use godot::classes::mesh::PrimitiveType;
 use godot::classes::{
-    ArrayMesh, Camera3D, ConcavePolygonShape3D, CollisionShape3D, INode3D, Node3D,
+    ArrayMesh, Camera3D, CollisionShape3D, ConcavePolygonShape3D, Engine, INode3D, Node3D,
     RenderingDevice, RenderingServer, Shader, ShaderMaterial, StaticBody3D,
 };
 use godot::prelude::*;
@@ -14,8 +14,20 @@ use crate::algo::run_algo::{CesRunAlgo, RunAlgoConfig};
 use crate::layers::sphere_terrain::CesSphereTerrain;
 use crate::layers::CesLayer;
 
+#[derive(Clone, Copy, PartialEq)]
+struct SettingsSnapshot {
+    radius: f32,
+    subdivisions: u32,
+    triangle_screen_size: f32,
+    low_poly_look: bool,
+    precise_normals: bool,
+    generate_collision: bool,
+    show_debug_messages: bool,
+    seed: i32,
+}
+
 #[derive(GodotClass)]
-#[class(base = Node3D)]
+#[class(tool, base = Node3D)]
 pub struct CesCelestialRust {
     base: Base<Node3D>,
 
@@ -56,6 +68,7 @@ pub struct CesCelestialRust {
     layers: Vec<Box<dyn CesLayer>>,
     last_cam_position: Vector3,
     last_obj_transform: Transform3D,
+    last_settings: SettingsSnapshot,
     values_updated: bool,
     is_shutting_down: bool,
 }
@@ -82,6 +95,16 @@ impl INode3D for CesCelestialRust {
             layers: Vec::new(),
             last_cam_position: Vector3::ZERO,
             last_obj_transform: Transform3D::IDENTITY,
+            last_settings: SettingsSnapshot {
+                radius: 1.0,
+                subdivisions: 3,
+                triangle_screen_size: 0.1,
+                low_poly_look: true,
+                precise_normals: true,
+                generate_collision: false,
+                show_debug_messages: false,
+                seed: 0,
+            },
             values_updated: false,
             is_shutting_down: false,
         }
@@ -104,6 +127,8 @@ impl INode3D for CesCelestialRust {
     fn ready(&mut self) {
         self.add_subnodes();
         self.layers = vec![Box::new(CesSphereTerrain::new())];
+        self.last_settings = self.current_settings();
+        self.values_updated = true;
     }
 
     fn process(&mut self, _delta: f64) {
@@ -122,8 +147,10 @@ impl INode3D for CesCelestialRust {
         let cam = cam.unwrap();
 
         let cam_pos = cam.get_global_position();
+        let current_settings = self.current_settings();
         let has_changed = global_transform != self.last_obj_transform
             || cam_pos != self.last_cam_position
+            || current_settings != self.last_settings
             || self.values_updated;
 
         if !has_changed {
@@ -132,6 +159,7 @@ impl INode3D for CesCelestialRust {
 
         self.last_obj_transform = global_transform;
         self.last_cam_position = cam_pos;
+        self.last_settings = current_settings;
         self.values_updated = false;
 
         let cam_local = global_transform.affine_inverse() * cam_pos;
@@ -163,10 +191,36 @@ impl INode3D for CesCelestialRust {
 }
 
 impl CesCelestialRust {
+    fn current_settings(&self) -> SettingsSnapshot {
+        SettingsSnapshot {
+            radius: self.radius,
+            subdivisions: self.subdivisions,
+            triangle_screen_size: self.triangle_screen_size,
+            low_poly_look: self.low_poly_look,
+            precise_normals: self.precise_normals,
+            generate_collision: self.generate_collision,
+            show_debug_messages: self.show_debug_messages,
+            seed: self.seed,
+        }
+    }
+
     fn get_camera(&self) -> Option<Gd<Camera3D>> {
         if let Some(ref cam) = self.gameplay_camera {
             return Some(cam.clone());
         }
+
+        if let Some(parent) = self.base().get_parent() {
+            if let Some(camera) = parent.try_get_node_as::<Camera3D>("Camera3D") {
+                return Some(camera);
+            }
+        }
+
+        if Engine::singleton().is_editor_hint() {
+            if let Some(camera) = self.base().get_viewport().and_then(|vp| vp.get_camera_3d()) {
+                return Some(camera);
+            }
+        }
+
         self.base().get_viewport().and_then(|vp| vp.get_camera_3d())
     }
 
@@ -217,8 +271,14 @@ impl CesCelestialRust {
         let mut surface_array = varray![];
         surface_array.resize(ArrayType::MAX.ord() as usize, &Variant::nil());
         surface_array.set(ArrayType::VERTEX.ord() as usize, &packed_verts.to_variant());
-        surface_array.set(ArrayType::NORMAL.ord() as usize, &packed_normals.to_variant());
-        surface_array.set(ArrayType::INDEX.ord() as usize, &packed_indices.to_variant());
+        surface_array.set(
+            ArrayType::NORMAL.ord() as usize,
+            &packed_normals.to_variant(),
+        );
+        surface_array.set(
+            ArrayType::INDEX.ord() as usize,
+            &packed_indices.to_variant(),
+        );
         surface_array.set(ArrayType::TEX_UV.ord() as usize, &packed_uvs.to_variant());
 
         let mut new_mesh = ArrayMesh::new_gd();

--- a/rust/src/compare_run_algo_test.rs
+++ b/rust/src/compare_run_algo_test.rs
@@ -1,0 +1,112 @@
+#[cfg(test)]
+mod tests {
+    use std::path::PathBuf;
+
+    fn workspace_root() -> PathBuf {
+        // rust/ is the crate root; workspace root is one level up
+        PathBuf::from(env!("CARGO_MANIFEST_DIR")).join("..")
+    }
+
+    fn load_mesh_json(path: &std::path::Path) -> (Vec<[f64; 3]>, Vec<i64>) {
+        let data = std::fs::read_to_string(path)
+            .unwrap_or_else(|e| panic!("Failed to read {}: {}", path.display(), e));
+        let val: serde_json::Value = serde_json::from_str(&data)
+            .unwrap_or_else(|e| panic!("Failed to parse JSON {}: {}", path.display(), e));
+
+        let vertices: Vec<[f64; 3]> = val["vertices"]
+            .as_array()
+            .expect("vertices should be an array")
+            .iter()
+            .map(|v| {
+                let arr = v.as_array().expect("vertex should be [x,y,z]");
+                [
+                    arr[0].as_f64().unwrap(),
+                    arr[1].as_f64().unwrap(),
+                    arr[2].as_f64().unwrap(),
+                ]
+            })
+            .collect();
+
+        let triangles: Vec<i64> = val["triangles"]
+            .as_array()
+            .expect("triangles should be an array")
+            .iter()
+            .map(|v| v.as_i64().unwrap())
+            .collect();
+
+        (vertices, triangles)
+    }
+
+    #[test]
+    fn compare_csharp_rust_run_algo() {
+        let root = workspace_root();
+        let csharp_path = root.join("debug/output/csharp_mesh.json");
+        let rust_path = root.join("debug/output/rust_mesh.json");
+
+        if !csharp_path.exists() || !rust_path.exists() {
+            panic!(
+                "JSON dumps not found. Run the dump scenes first:\n  \
+                 ./debug/run_scene_with_log.sh \"$PWD\" res://debug/scenes/DumpRunAlgoCSharp.tscn\n  \
+                 ./debug/run_scene_with_log.sh \"$PWD\" res://debug/scenes/DumpRunAlgoRust.tscn"
+            );
+        }
+
+        let (cs_verts, cs_tris) = load_mesh_json(&csharp_path);
+        let (rs_verts, rs_tris) = load_mesh_json(&rust_path);
+
+        // Compare vertex counts
+        assert_eq!(
+            cs_verts.len(),
+            rs_verts.len(),
+            "Vertex count mismatch: C#={} Rust={}",
+            cs_verts.len(),
+            rs_verts.len()
+        );
+
+        // Compare triangle counts
+        assert_eq!(
+            cs_tris.len(),
+            rs_tris.len(),
+            "Triangle index count mismatch: C#={} Rust={}",
+            cs_tris.len(),
+            rs_tris.len()
+        );
+
+        // Compare vertices with tolerance
+        let tol = 1e-5;
+        let mut max_diff: f64 = 0.0;
+        for (i, (cv, rv)) in cs_verts.iter().zip(rs_verts.iter()).enumerate() {
+            for axis in 0..3 {
+                let diff = (cv[axis] - rv[axis]).abs();
+                if diff > max_diff {
+                    max_diff = diff;
+                }
+                assert!(
+                    diff < tol,
+                    "Vertex {} axis {} differs: C#={} Rust={} diff={}",
+                    i,
+                    axis,
+                    cv[axis],
+                    rv[axis],
+                    diff
+                );
+            }
+        }
+
+        // Compare triangle indices exactly
+        for (i, (ct, rt)) in cs_tris.iter().zip(rs_tris.iter()).enumerate() {
+            assert_eq!(
+                ct, rt,
+                "Triangle index {} differs: C#={} Rust={}",
+                i, ct, rt
+            );
+        }
+
+        println!(
+            "PASS: {} vertices, {} triangle indices match (max vertex diff: {:.2e})",
+            cs_verts.len(),
+            cs_tris.len(),
+            max_diff
+        );
+    }
+}

--- a/rust/src/compositor.rs
+++ b/rust/src/compositor.rs
@@ -1,0 +1,46 @@
+use godot::classes::compositor_effect::EffectCallbackType;
+use godot::classes::{CompositorEffect, ICompositorEffect};
+use godot::prelude::*;
+
+/// Compositor effect that renders CesState geometry in scene space.
+#[derive(GodotClass)]
+#[class(tool, base = CompositorEffect)]
+pub struct CesFinalStateCompositorRust {
+    base: Base<CompositorEffect>,
+
+    #[export]
+    target_path: NodePath,
+
+    #[export]
+    target_position: Vector3,
+
+    #[export]
+    radius: f32,
+
+    #[export]
+    ambient_strength: f32,
+
+    #[export]
+    sphere_color: Color,
+}
+
+#[godot_api]
+impl ICompositorEffect for CesFinalStateCompositorRust {
+    fn init(base: Base<CompositorEffect>) -> Self {
+        let mut s = Self {
+            base,
+            target_path: NodePath::default(),
+            target_position: Vector3::ZERO,
+            radius: 1.0,
+            ambient_strength: 0.05,
+            sphere_color: Color::from_rgb(0.0, 0.0, 0.0),
+        };
+        s.base_mut()
+            .set_effect_callback_type(EffectCallbackType::POST_TRANSPARENT);
+        s.base_mut().set_access_resolved_color(true);
+        s.base_mut().set_access_resolved_depth(true);
+        s
+    }
+
+    // TODO: Implement render_callback in Phase 3
+}

--- a/rust/src/compute_utils.rs
+++ b/rust/src/compute_utils.rs
@@ -103,59 +103,109 @@ pub fn create_uniform_buffer<T: bytemuck::Pod>(
     BufferInfo::new_uniform(rid)
 }
 
-/// Loads a .slang shader resource, gets SPIR-V, creates pipeline, dispatches compute, and syncs.
-/// The entire dispatch runs on the render thread (fire-and-forget).
-pub fn dispatch_shader(
+/// Updates an existing uniform buffer with new data (16-byte aligned).
+/// The buffer must already exist and be large enough.
+pub fn update_uniform_buffer<T: bytemuck::Pod>(
     rd: &mut Gd<RenderingDevice>,
-    shader_path: &str,
-    buffers: &[&BufferInfo],
-    threads: u32,
+    buffer: &BufferInfo,
+    value: &T,
 ) {
-    // Extract plain-data info (Send-safe) to build uniforms inside the closure
-    let buffer_descs: Vec<(Rid, crate::buffer_info::BufferType)> =
-        buffers.iter().map(|b| (b.rid, b.buffer_type)).collect();
+    let data_bytes = bytemuck::bytes_of(value);
+    let padded_size = 16.max((data_bytes.len() + 15) / 16 * 16);
+    let mut padded = vec![0u8; padded_size];
+    padded[..data_bytes.len()].copy_from_slice(data_bytes);
 
+    let rid = buffer.rid;
     let rd_send = RdSend(rd.clone());
-    let shader_path = shader_path.to_string();
-
     on_render_thread(move || {
-        let mut rd = rd_send; // force whole-struct capture (Rust 2021)
-        let mut shader_resource = load::<godot::classes::Resource>(&shader_path);
-        let spirv = shader_resource
-            .call("get_spirv", &[])
-            .to::<Gd<godot::classes::RdShaderSpirv>>();
-        let compute_shader = rd.0.shader_create_from_spirv(&spirv);
-        assert!(
-            compute_shader.is_valid(),
-            "Failed to create shader from SPIR-V"
-        );
-
-        let pipeline = rd.0.compute_pipeline_create(compute_shader);
-        let compute_list = rd.0.compute_list_begin();
-        rd.0.compute_list_bind_compute_pipeline(compute_list, pipeline);
-
-        let mut uniform_array = Array::<Gd<RdUniform>>::new();
-        for (i, (rid, btype)) in buffer_descs.into_iter().enumerate() {
-            let mut uniform = RdUniform::new_gd();
-            uniform.set_uniform_type(btype.to_uniform_type());
-            uniform.set_binding(i as i32);
-            uniform.add_id(rid);
-            uniform_array.push(&uniform);
-        }
-        let uniform_set = rd.0.uniform_set_create(&uniform_array, compute_shader, 0);
-        assert!(uniform_set.is_valid(), "Failed to create uniform set");
-        rd.0.compute_list_bind_uniform_set(compute_list, uniform_set, 0);
-
-        rd.0.compute_list_dispatch(compute_list, threads, 1, 1);
-        rd.0.compute_list_end();
-        rd.0.submit();
-        rd.0.sync();
-
-        // Free transient GPU objects
-        rd.0.free_rid(uniform_set);
-        rd.0.free_rid(pipeline);
-        rd.0.free_rid(compute_shader);
+        let mut rd = rd_send;
+        let mut pba = PackedByteArray::new();
+        pba.extend(padded.iter().copied());
+        rd.0.buffer_update(rid, 0, padded_size as u32, &pba);
     });
+}
+
+/// Cached compute pipeline. Owns the shader and pipeline RIDs; they are freed on drop.
+pub struct ComputePipeline {
+    rd: RdSend,
+    shader: Rid,
+    pipeline: Rid,
+}
+
+impl ComputePipeline {
+    /// Loads the shader from `shader_path`, creates SPIR-V and pipeline.
+    /// Blocks until the render-thread work completes.
+    pub fn new(rd: &mut Gd<RenderingDevice>, shader_path: &str) -> Self {
+        let rd_send = RdSend(rd.clone());
+        let shader_path = shader_path.to_string();
+
+        let (shader, pipeline) = on_render_thread_sync(move || {
+            let mut rd = rd_send;
+            let mut shader_resource = load::<godot::classes::Resource>(&shader_path);
+            let spirv = shader_resource
+                .call("get_spirv", &[])
+                .to::<Gd<godot::classes::RdShaderSpirv>>();
+            let shader = rd.0.shader_create_from_spirv(&spirv);
+            assert!(shader.is_valid(), "Failed to create shader from SPIR-V");
+            let pipeline = rd.0.compute_pipeline_create(shader);
+            assert!(pipeline.is_valid(), "Failed to create compute pipeline");
+            (shader, pipeline)
+        });
+
+        Self {
+            rd: RdSend(rd.clone()),
+            shader,
+            pipeline,
+        }
+    }
+
+    /// Dispatches the cached pipeline. Only the uniform set is created (and freed) per call.
+    pub fn dispatch(&self, rd: &mut Gd<RenderingDevice>, buffers: &[&BufferInfo], threads: u32) {
+        let buffer_descs: Vec<(Rid, crate::buffer_info::BufferType)> =
+            buffers.iter().map(|b| (b.rid, b.buffer_type)).collect();
+
+        let rd_send = RdSend(rd.clone());
+        let shader = self.shader;
+        let pipeline = self.pipeline;
+
+        on_render_thread(move || {
+            let mut rd = rd_send;
+            let compute_list = rd.0.compute_list_begin();
+            rd.0.compute_list_bind_compute_pipeline(compute_list, pipeline);
+
+            let mut uniform_array = Array::<Gd<RdUniform>>::new();
+            for (i, (rid, btype)) in buffer_descs.into_iter().enumerate() {
+                let mut uniform = RdUniform::new_gd();
+                uniform.set_uniform_type(btype.to_uniform_type());
+                uniform.set_binding(i as i32);
+                uniform.add_id(rid);
+                uniform_array.push(&uniform);
+            }
+            let uniform_set = rd.0.uniform_set_create(&uniform_array, shader, 0);
+            assert!(uniform_set.is_valid(), "Failed to create uniform set");
+            rd.0.compute_list_bind_uniform_set(compute_list, uniform_set, 0);
+
+            rd.0.compute_list_dispatch(compute_list, threads, 1, 1);
+            rd.0.compute_list_end();
+            rd.0.submit();
+            rd.0.sync();
+
+            rd.0.free_rid(uniform_set);
+        });
+    }
+}
+
+impl Drop for ComputePipeline {
+    fn drop(&mut self) {
+        let rd_send = RdSend(self.rd.0.clone());
+        let shader = self.shader;
+        let pipeline = self.pipeline;
+        on_render_thread(move || {
+            let mut rd = rd_send;
+            rd.0.free_rid(pipeline);
+            rd.0.free_rid(shader);
+        });
+    }
 }
 
 /// Reads a GPU buffer back to CPU and reinterprets as a Vec<T>.

--- a/rust/src/compute_utils.rs
+++ b/rust/src/compute_utils.rs
@@ -1,27 +1,92 @@
-use godot::builtin::{PackedByteArray, Vector3};
+use godot::builtin::{Callable, PackedByteArray, Variant, Vector3};
 use godot::classes::RdUniform;
-use godot::classes::RenderingDevice;
-use godot::obj::Gd;
-use godot::prelude::load;
+use godot::classes::{RenderingDevice, RenderingServer};
+use godot::obj::{Gd, NewGd, Singleton};
+use godot::prelude::{load, Array, Rid};
+
+use std::sync::Mutex;
 
 use crate::buffer_info::BufferInfo;
 
+// ---------------------------------------------------------------------------
+// Render-thread dispatch helpers (mirrors C# CallOnRenderThread pattern)
+// ---------------------------------------------------------------------------
+
+/// Newtype to send `Gd<RenderingDevice>` across threads.
+/// SAFETY: The wrapped RD is a local RenderingDevice created via
+/// `create_local_rendering_device()`. Actual RD method calls only happen on
+/// the render thread (via `call_on_render_thread`), so there is no concurrent
+/// unsynchronized access.
+pub(crate) struct RdSend(pub Gd<RenderingDevice>);
+unsafe impl Send for RdSend {}
+
+/// Schedules `f` to run on the render thread (fire-and-forget).
+pub fn on_render_thread(f: impl FnOnce() + Send + 'static) {
+    let f = Mutex::new(Some(f));
+    let callable = Callable::from_sync_fn("rt_fire", move |_args: &[&Variant]| {
+        if let Some(f) = f.lock().unwrap().take() {
+            f();
+        }
+    });
+    RenderingServer::singleton().call_on_render_thread(&callable);
+}
+
+/// Schedules `f` to run on the render thread and blocks until the result is
+/// available.  Mirrors C#'s `CallOnRenderThread` + `ManualResetEventSlim`.
+pub fn on_render_thread_sync<T: Send + 'static>(f: impl FnOnce() -> T + Send + 'static) -> T {
+    let (tx, rx) = std::sync::mpsc::sync_channel(1);
+    on_render_thread(move || {
+        let result = f();
+        let _ = tx.send(result);
+    });
+    rx.recv().expect("render thread work failed")
+}
+
+/// Frees a GPU RID on the render thread (fire-and-forget).
+pub fn free_rid_on_render_thread(rd: &mut Gd<RenderingDevice>, rid: Rid) {
+    let rd_send = RdSend(rd.clone());
+    on_render_thread(move || {
+        let mut rd = rd_send; // force whole-struct capture (Rust 2021)
+        rd.0.free_rid(rid);
+    });
+}
+
+/// Clears a GPU buffer on the render thread (fire-and-forget).
+pub fn buffer_clear_on_render_thread(
+    rd: &mut Gd<RenderingDevice>,
+    rid: Rid,
+    offset: u32,
+    size: u32,
+) {
+    let rd_send = RdSend(rd.clone());
+    on_render_thread(move || {
+        let mut rd = rd_send; // force whole-struct capture (Rust 2021)
+        rd.0.buffer_clear(rid, offset, size);
+    });
+}
+
 /// Creates a GPU storage buffer from typed data.
-pub fn create_storage_buffer<T: bytemuck::Pod>(rd: &mut RenderingDevice, data: &[T]) -> BufferInfo {
+pub fn create_storage_buffer<T: bytemuck::Pod>(
+    rd: &mut Gd<RenderingDevice>,
+    data: &[T],
+) -> BufferInfo {
     let bytes = bytemuck::cast_slice(data);
     create_storage_buffer_from_bytes(rd, bytes)
 }
 
 /// Creates a zeroed GPU storage buffer of the given byte length.
-pub fn create_empty_storage_buffer(rd: &mut RenderingDevice, byte_length: u32) -> BufferInfo {
+pub fn create_empty_storage_buffer(rd: &mut Gd<RenderingDevice>, byte_length: u32) -> BufferInfo {
     let rid = rd.storage_buffer_create(byte_length);
     assert!(rid.is_valid(), "Failed to create empty storage buffer");
-    rd.buffer_clear(rid, 0, byte_length);
+    buffer_clear_on_render_thread(rd, rid, 0, byte_length);
     BufferInfo::new_storage(rid, byte_length, byte_length)
 }
 
 /// Creates a uniform buffer from a single value, with 16-byte alignment padding.
-pub fn create_uniform_buffer<T: bytemuck::Pod>(rd: &mut RenderingDevice, value: &T) -> BufferInfo {
+pub fn create_uniform_buffer<T: bytemuck::Pod>(
+    rd: &mut Gd<RenderingDevice>,
+    value: &T,
+) -> BufferInfo {
     let data_bytes = bytemuck::bytes_of(value);
     // Pad to 16-byte alignment as required by Godot's uniform buffer spec
     let padded_size = 16.max((data_bytes.len() + 15) / 16 * 16);
@@ -39,65 +104,87 @@ pub fn create_uniform_buffer<T: bytemuck::Pod>(rd: &mut RenderingDevice, value: 
 }
 
 /// Loads a .slang shader resource, gets SPIR-V, creates pipeline, dispatches compute, and syncs.
+/// The entire dispatch runs on the render thread (fire-and-forget).
 pub fn dispatch_shader(
-    rd: &mut RenderingDevice,
+    rd: &mut Gd<RenderingDevice>,
     shader_path: &str,
     buffers: &[&BufferInfo],
     threads: u32,
 ) {
-    // Build uniforms array
-    let uniforms: Vec<Gd<RdUniform>> = buffers
-        .iter()
-        .enumerate()
-        .map(|(i, b)| b.get_uniform_with_binding(i as i32))
-        .collect();
+    // Extract plain-data info (Send-safe) to build uniforms inside the closure
+    let buffer_descs: Vec<(Rid, crate::buffer_info::BufferType)> =
+        buffers.iter().map(|b| (b.rid, b.buffer_type)).collect();
 
-    // Load shader resource and get SPIR-V
-    let mut shader_resource = load::<godot::classes::Resource>(shader_path);
-    let spirv = shader_resource
-        .call("get_spirv", &[])
-        .to::<Gd<godot::classes::RdShaderSpirv>>();
-    let compute_shader = rd.shader_create_from_spirv(&spirv);
-    assert!(
-        compute_shader.is_valid(),
-        "Failed to create shader from SPIR-V"
-    );
+    let rd_send = RdSend(rd.clone());
+    let shader_path = shader_path.to_string();
 
-    let pipeline = rd.compute_pipeline_create(compute_shader);
-    let compute_list = rd.compute_list_begin();
-    rd.compute_list_bind_compute_pipeline(compute_list, pipeline);
+    on_render_thread(move || {
+        let mut rd = rd_send; // force whole-struct capture (Rust 2021)
+        let mut shader_resource = load::<godot::classes::Resource>(&shader_path);
+        let spirv = shader_resource
+            .call("get_spirv", &[])
+            .to::<Gd<godot::classes::RdShaderSpirv>>();
+        let compute_shader = rd.0.shader_create_from_spirv(&spirv);
+        assert!(
+            compute_shader.is_valid(),
+            "Failed to create shader from SPIR-V"
+        );
 
-    // Create uniform set from the array
-    let mut uniform_array = godot::prelude::Array::<Gd<RdUniform>>::new();
-    for u in uniforms {
-        uniform_array.push(&u);
-    }
-    let uniform_set = rd.uniform_set_create(&uniform_array, compute_shader, 0);
-    assert!(uniform_set.is_valid(), "Failed to create uniform set");
-    rd.compute_list_bind_uniform_set(compute_list, uniform_set, 0);
+        let pipeline = rd.0.compute_pipeline_create(compute_shader);
+        let compute_list = rd.0.compute_list_begin();
+        rd.0.compute_list_bind_compute_pipeline(compute_list, pipeline);
 
-    rd.compute_list_dispatch(compute_list, threads, 1, 1);
-    rd.compute_list_end();
-    rd.submit();
-    rd.sync();
+        let mut uniform_array = Array::<Gd<RdUniform>>::new();
+        for (i, (rid, btype)) in buffer_descs.into_iter().enumerate() {
+            let mut uniform = RdUniform::new_gd();
+            uniform.set_uniform_type(btype.to_uniform_type());
+            uniform.set_binding(i as i32);
+            uniform.add_id(rid);
+            uniform_array.push(&uniform);
+        }
+        let uniform_set = rd.0.uniform_set_create(&uniform_array, compute_shader, 0);
+        assert!(uniform_set.is_valid(), "Failed to create uniform set");
+        rd.0.compute_list_bind_uniform_set(compute_list, uniform_set, 0);
+
+        rd.0.compute_list_dispatch(compute_list, threads, 1, 1);
+        rd.0.compute_list_end();
+        rd.0.submit();
+        rd.0.sync();
+
+        // Free transient GPU objects
+        rd.0.free_rid(uniform_set);
+        rd.0.free_rid(pipeline);
+        rd.0.free_rid(compute_shader);
+    });
 }
 
 /// Reads a GPU buffer back to CPU and reinterprets as a Vec<T>.
-pub fn convert_buffer_to_vec<T: bytemuck::Pod>(
-    rd: &mut RenderingDevice,
+/// Blocks until the render thread completes the read.
+pub fn convert_buffer_to_vec<T: bytemuck::Pod + Send>(
+    rd: &mut Gd<RenderingDevice>,
     buffer: &BufferInfo,
 ) -> Vec<T> {
-    let byte_data = rd
-        .buffer_get_data_ex(buffer.rid)
-        .offset_bytes(0)
-        .size_bytes(buffer.filled_size)
-        .done();
-    let bytes = byte_data.as_slice();
-    bytemuck::cast_slice(bytes).to_vec()
+    let rd_send = RdSend(rd.clone());
+    let rid = buffer.rid;
+    let filled_size = buffer.filled_size;
+
+    on_render_thread_sync(move || {
+        let mut rd = rd_send; // force whole-struct capture (Rust 2021)
+        let byte_data =
+            rd.0.buffer_get_data_ex(rid)
+                .offset_bytes(0)
+                .size_bytes(filled_size)
+                .done();
+        let bytes = byte_data.as_slice();
+        bytemuck::cast_slice::<u8, T>(bytes).to_vec()
+    })
 }
 
 /// Reads a float4 GPU buffer and converts to Vec<Vector3> (discarding w).
-pub fn convert_v4_buffer_to_vec3(rd: &mut RenderingDevice, buffer: &BufferInfo) -> Vec<Vector3> {
+pub fn convert_v4_buffer_to_vec3(
+    rd: &mut Gd<RenderingDevice>,
+    buffer: &BufferInfo,
+) -> Vec<Vector3> {
     let float_data: Vec<f32> = convert_buffer_to_vec(rd, buffer);
     let num_vectors = float_data.len() / 4;
     let mut result = Vec::with_capacity(num_vectors);
@@ -130,7 +217,7 @@ pub fn sum_array_in_place(arr: &mut [i32], invert: bool) {
 
 // --- internal helper ---
 
-fn create_storage_buffer_from_bytes(rd: &mut RenderingDevice, bytes: &[u8]) -> BufferInfo {
+fn create_storage_buffer_from_bytes(rd: &mut Gd<RenderingDevice>, bytes: &[u8]) -> BufferInfo {
     let len = bytes.len() as u32;
     let mut pba = PackedByteArray::new();
     pba.extend(bytes.iter().copied());

--- a/rust/src/cpu_subdivide.rs
+++ b/rust/src/cpu_subdivide.rs
@@ -1,0 +1,328 @@
+use crate::initial_state::{TRIANGLES, VERTICES};
+
+/// CPU-only icosphere subdivision (1→4 split) WITHOUT edge deduplication.
+///
+/// Matches the GPU shader behavior (DivideLOD.slang with preciseNormals=false):
+/// each triangle gets 3 new midpoint vertices (no sharing with neighbors).
+/// After subdivision, vertices are normalized to the unit sphere surface.
+pub fn cpu_subdivide_once(
+    vertices: &[[f32; 4]],
+    triangles: &[[i32; 4]],
+) -> (Vec<[f32; 4]>, Vec<[i32; 4]>) {
+    let n = triangles.len();
+    let n_verts = vertices.len() as i32;
+
+    // New child triangles
+    let mut new_triangles: Vec<[i32; 4]> = Vec::with_capacity(n * 4);
+    // New midpoint positions: 3 per triangle
+    let mut new_vertex_positions: Vec<[f32; 4]> = Vec::with_capacity(n * 3);
+
+    for div_index in 0..n {
+        let [a, b, c, _] = triangles[div_index];
+
+        // Shader logic: v_idx_start = nVerts + 3 * divTrisIndex
+        let v_idx_start = n_verts + 3 * div_index as i32;
+        let mid_ab = v_idx_start;
+        let mid_bc = v_idx_start + 1;
+        let mid_ca = v_idx_start + 2;
+
+        // Compute midpoint positions: (v[a] + v[b]) / 2
+        let va = vertices[a as usize];
+        let vb = vertices[b as usize];
+        let vc = vertices[c as usize];
+
+        new_vertex_positions.push([
+            (va[0] + vb[0]) * 0.5,
+            (va[1] + vb[1]) * 0.5,
+            (va[2] + vb[2]) * 0.5,
+            0.0,
+        ]);
+        new_vertex_positions.push([
+            (vb[0] + vc[0]) * 0.5,
+            (vb[1] + vc[1]) * 0.5,
+            (vb[2] + vc[2]) * 0.5,
+            0.0,
+        ]);
+        new_vertex_positions.push([
+            (vc[0] + va[0]) * 0.5,
+            (vc[1] + va[1]) * 0.5,
+            (vc[2] + va[2]) * 0.5,
+            0.0,
+        ]);
+
+        // 4 child triangles (matches shader add_triangles):
+        // child 0: (a, midAB, midCA)
+        new_triangles.push([a, mid_ab, mid_ca, 0]);
+        // child 1: (midAB, b, midBC)
+        new_triangles.push([mid_ab, b, mid_bc, 0]);
+        // child 2: (midCA, midBC, c)
+        new_triangles.push([mid_ca, mid_bc, c, 0]);
+        // child 3: (midBC, midCA, midAB) — center triangle
+        new_triangles.push([mid_bc, mid_ca, mid_ab, 0]);
+    }
+
+    // Build final vertex array: original + new midpoints
+    let mut out_vertices: Vec<[f32; 4]> = vertices.to_vec();
+    out_vertices.extend(new_vertex_positions);
+
+    // Normalize all vertices to unit sphere
+    for v in out_vertices.iter_mut() {
+        let mag = (v[0] * v[0] + v[1] * v[1] + v[2] * v[2]).sqrt();
+        if mag > 0.0 {
+            v[0] /= mag;
+            v[1] /= mag;
+            v[2] /= mag;
+        }
+        v[3] = 0.0;
+    }
+
+    (out_vertices, new_triangles)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_cpu_subdivide_counts() {
+        let (verts, tris) = cpu_subdivide_once(&VERTICES, &TRIANGLES);
+        assert_eq!(tris.len(), 80, "Expected 80 triangles after 1 subdivision");
+        assert_eq!(
+            verts.len(),
+            72,
+            "Expected 72 vertices after 1 subdivision (12 + 20*3 midpoints, no dedup)"
+        );
+    }
+
+    #[test]
+    fn test_cpu_subdivide_vertices_on_sphere() {
+        let (verts, _) = cpu_subdivide_once(&VERTICES, &TRIANGLES);
+        for (i, v) in verts.iter().enumerate() {
+            let mag = (v[0] * v[0] + v[1] * v[1] + v[2] * v[2]).sqrt();
+            assert!(
+                (mag - 1.0).abs() < 1e-5,
+                "Vertex {} has magnitude {}, expected ~1.0",
+                i,
+                mag,
+            );
+        }
+    }
+
+    #[test]
+    fn test_cpu_subdivide_no_degenerate_triangles() {
+        let (_, tris) = cpu_subdivide_once(&VERTICES, &TRIANGLES);
+        for (i, t) in tris.iter().enumerate() {
+            assert!(
+                t[0] != t[1] && t[1] != t[2] && t[0] != t[2],
+                "Triangle {} has duplicate vertex indices: [{}, {}, {}]",
+                i,
+                t[0],
+                t[1],
+                t[2],
+            );
+        }
+    }
+
+    /// C# reference vertex positions after 1 subdivision with preciseNormals=false,
+    /// then sphere normalization (radius=1.0).
+    /// Extracted from C# CesDivLOD + SphereTerrain GPU shader output.
+    #[rustfmt::skip]
+    const CSHARP_REF_VERTICES: [[f32; 4]; 72] = [
+        [-0.525686502, 0.0, 0.850678265, 0.0],       // 0
+        [0.525686502, 0.0, 0.850678265, 0.0],        // 1
+        [-0.525686502, 0.0, -0.850678265, 0.0],      // 2
+        [0.525686502, 0.0, -0.850678265, 0.0],       // 3
+        [0.0, 0.850678265, 0.525686502, 0.0],        // 4
+        [0.0, 0.850678265, -0.525686502, 0.0],       // 5
+        [0.0, -0.850678265, 0.525686502, 0.0],       // 6
+        [0.0, -0.850678265, -0.525686502, 0.0],      // 7
+        [0.850678265, 0.525686502, 0.0, 0.0],        // 8
+        [-0.850678265, 0.525686502, 0.0, 0.0],       // 9
+        [0.850678265, -0.525686502, 0.0, 0.0],       // 10
+        [-0.850678265, -0.525686502, 0.0, 0.0],      // 11
+        [-0.30899331, 0.500020206, 0.809013486, 0.0], // 12
+        [0.30899331, 0.500020206, 0.809013486, 0.0],  // 13
+        [0.0, 0.0, 0.99999994, 0.0],                  // 14
+        [-0.809013486, 0.30899331, 0.500020206, 0.0],  // 15
+        [-0.500020206, 0.809013486, 0.30899331, 0.0],  // 16
+        [-0.30899331, 0.500020206, 0.809013486, 0.0],  // 17
+        [-0.500020206, 0.809013486, -0.30899331, 0.0], // 18
+        [0.0, 0.99999994, 0.0, 0.0],                   // 19
+        [-0.500020206, 0.809013486, 0.30899331, 0.0],  // 20
+        [0.0, 0.99999994, 0.0, 0.0],                   // 21
+        [0.500020206, 0.809013486, -0.30899331, 0.0],  // 22
+        [0.500020206, 0.809013486, 0.30899331, 0.0],   // 23
+        [0.500020206, 0.809013486, 0.30899331, 0.0],   // 24
+        [0.809013486, 0.30899331, 0.500020206, 0.0],   // 25
+        [0.30899331, 0.500020206, 0.809013486, 0.0],   // 26
+        [0.99999994, 0.0, 0.0, 0.0],                   // 27
+        [0.809013486, -0.30899331, 0.500020206, 0.0],  // 28
+        [0.809013486, 0.30899331, 0.500020206, 0.0],   // 29
+        [0.809013486, 0.30899331, -0.500020206, 0.0],  // 30
+        [0.809013486, -0.30899331, -0.500020206, 0.0], // 31
+        [0.99999994, 0.0, 0.0, 0.0],                   // 32
+        [0.30899331, 0.500020206, -0.809013486, 0.0],  // 33
+        [0.809013486, 0.30899331, -0.500020206, 0.0],  // 34
+        [0.500020206, 0.809013486, -0.30899331, 0.0],  // 35
+        [-0.30899331, 0.500020206, -0.809013486, 0.0], // 36
+        [0.0, 0.0, -0.99999994, 0.0],                  // 37
+        [0.30899331, 0.500020206, -0.809013486, 0.0],  // 38
+        [-0.30899331, -0.500020206, -0.809013486, 0.0],// 39
+        [0.30899331, -0.500020206, -0.809013486, 0.0], // 40
+        [0.0, 0.0, -0.99999994, 0.0],                  // 41
+        [0.500020206, -0.809013486, -0.30899331, 0.0], // 42
+        [0.809013486, -0.30899331, -0.500020206, 0.0], // 43
+        [0.30899331, -0.500020206, -0.809013486, 0.0], // 44
+        [0.0, -0.99999994, 0.0, 0.0],                  // 45
+        [0.500020206, -0.809013486, 0.30899331, 0.0],  // 46
+        [0.500020206, -0.809013486, -0.30899331, 0.0], // 47
+        [-0.500020206, -0.809013486, -0.30899331, 0.0],// 48
+        [-0.500020206, -0.809013486, 0.30899331, 0.0], // 49
+        [0.0, -0.99999994, 0.0, 0.0],                  // 50
+        [-0.809013486, -0.30899331, 0.500020206, 0.0], // 51
+        [-0.30899331, -0.500020206, 0.809013486, 0.0], // 52
+        [-0.500020206, -0.809013486, 0.30899331, 0.0], // 53
+        [0.0, 0.0, 0.99999994, 0.0],                   // 54
+        [0.30899331, -0.500020206, 0.809013486, 0.0],  // 55
+        [-0.30899331, -0.500020206, 0.809013486, 0.0], // 56
+        [0.30899331, -0.500020206, 0.809013486, 0.0],  // 57
+        [0.809013486, -0.30899331, 0.500020206, 0.0],  // 58
+        [0.500020206, -0.809013486, 0.30899331, 0.0],  // 59
+        [-0.809013486, 0.30899331, 0.500020206, 0.0],  // 60
+        [-0.809013486, -0.30899331, 0.500020206, 0.0], // 61
+        [-0.99999994, 0.0, 0.0, 0.0],                  // 62
+        [-0.99999994, 0.0, 0.0, 0.0],                  // 63
+        [-0.809013486, -0.30899331, -0.500020206, 0.0],// 64
+        [-0.809013486, 0.30899331, -0.500020206, 0.0], // 65
+        [-0.809013486, 0.30899331, -0.500020206, 0.0], // 66
+        [-0.30899331, 0.500020206, -0.809013486, 0.0], // 67
+        [-0.500020206, 0.809013486, -0.30899331, 0.0], // 68
+        [-0.30899331, -0.500020206, -0.809013486, 0.0],// 69
+        [-0.809013486, -0.30899331, -0.500020206, 0.0],// 70
+        [-0.500020206, -0.809013486, -0.30899331, 0.0],// 71
+    ];
+
+    /// C# reference child triangle indices after 1 subdivision.
+    /// These are the 80 child triangles (indices 20-99 in the full buffer,
+    /// but stored here as 0-79 since we only output children).
+    #[rustfmt::skip]
+    const CSHARP_REF_TRIANGLES: [[i32; 4]; 80] = [
+        [0, 12, 14, 0],   // 0 (was T20)
+        [12, 4, 13, 0],   // 1
+        [14, 13, 1, 0],   // 2
+        [13, 14, 12, 0],  // 3
+        [0, 15, 17, 0],   // 4
+        [15, 9, 16, 0],   // 5
+        [17, 16, 4, 0],   // 6
+        [16, 17, 15, 0],  // 7
+        [9, 18, 20, 0],   // 8
+        [18, 5, 19, 0],   // 9
+        [20, 19, 4, 0],   // 10
+        [19, 20, 18, 0],  // 11
+        [4, 21, 23, 0],   // 12
+        [21, 5, 22, 0],   // 13
+        [23, 22, 8, 0],   // 14
+        [22, 23, 21, 0],  // 15
+        [4, 24, 26, 0],   // 16
+        [24, 8, 25, 0],   // 17
+        [26, 25, 1, 0],   // 18
+        [25, 26, 24, 0],  // 19
+        [8, 27, 29, 0],   // 20
+        [27, 10, 28, 0],  // 21
+        [29, 28, 1, 0],   // 22
+        [28, 29, 27, 0],  // 23
+        [8, 30, 32, 0],   // 24
+        [30, 3, 31, 0],   // 25
+        [32, 31, 10, 0],  // 26
+        [31, 32, 30, 0],  // 27
+        [5, 33, 35, 0],   // 28
+        [33, 3, 34, 0],   // 29
+        [35, 34, 8, 0],   // 30
+        [34, 35, 33, 0],  // 31
+        [5, 36, 38, 0],   // 32
+        [36, 2, 37, 0],   // 33
+        [38, 37, 3, 0],   // 34
+        [37, 38, 36, 0],  // 35
+        [2, 39, 41, 0],   // 36
+        [39, 7, 40, 0],   // 37
+        [41, 40, 3, 0],   // 38
+        [40, 41, 39, 0],  // 39
+        [7, 42, 44, 0],   // 40
+        [42, 10, 43, 0],  // 41
+        [44, 43, 3, 0],   // 42
+        [43, 44, 42, 0],  // 43
+        [7, 45, 47, 0],   // 44
+        [45, 6, 46, 0],   // 45
+        [47, 46, 10, 0],  // 46
+        [46, 47, 45, 0],  // 47
+        [7, 48, 50, 0],   // 48
+        [48, 11, 49, 0],  // 49
+        [50, 49, 6, 0],   // 50
+        [49, 50, 48, 0],  // 51
+        [11, 51, 53, 0],  // 52
+        [51, 0, 52, 0],   // 53
+        [53, 52, 6, 0],   // 54
+        [52, 53, 51, 0],  // 55
+        [0, 54, 56, 0],   // 56
+        [54, 1, 55, 0],   // 57
+        [56, 55, 6, 0],   // 58
+        [55, 56, 54, 0],  // 59
+        [6, 57, 59, 0],   // 60
+        [57, 1, 58, 0],   // 61
+        [59, 58, 10, 0],  // 62
+        [58, 59, 57, 0],  // 63
+        [9, 60, 62, 0],   // 64
+        [60, 0, 61, 0],   // 65
+        [62, 61, 11, 0],  // 66
+        [61, 62, 60, 0],  // 67
+        [9, 63, 65, 0],   // 68
+        [63, 11, 64, 0],  // 69
+        [65, 64, 2, 0],   // 70
+        [64, 65, 63, 0],  // 71
+        [9, 66, 68, 0],   // 72
+        [66, 2, 67, 0],   // 73
+        [68, 67, 5, 0],   // 74
+        [67, 68, 66, 0],  // 75
+        [7, 69, 71, 0],   // 76
+        [69, 2, 70, 0],   // 77
+        [71, 70, 11, 0],  // 78
+        [70, 71, 69, 0],  // 79
+    ];
+
+    /// Verify that the CPU Rust subdivision matches C# reference vertex positions.
+    #[test]
+    fn test_cpu_subdivide_matches_csharp_vertices() {
+        let (verts, _) = cpu_subdivide_once(&VERTICES, &TRIANGLES);
+        assert_eq!(verts.len(), CSHARP_REF_VERTICES.len());
+
+        for (i, (rust_v, csharp_v)) in verts.iter().zip(CSHARP_REF_VERTICES.iter()).enumerate() {
+            for comp in 0..3 {
+                let diff = (rust_v[comp] - csharp_v[comp]).abs();
+                assert!(
+                    diff < 1e-4,
+                    "Vertex {} component {} mismatch: rust={} csharp={} diff={}",
+                    i,
+                    comp,
+                    rust_v[comp],
+                    csharp_v[comp],
+                    diff,
+                );
+            }
+        }
+    }
+
+    /// Verify that the CPU Rust subdivision matches C# reference triangle indices.
+    #[test]
+    fn test_cpu_subdivide_matches_csharp_triangles() {
+        let (_, tris) = cpu_subdivide_once(&VERTICES, &TRIANGLES);
+        assert_eq!(tris.len(), CSHARP_REF_TRIANGLES.len());
+
+        for (i, (rust_t, csharp_t)) in tris.iter().zip(CSHARP_REF_TRIANGLES.iter()).enumerate() {
+            assert_eq!(
+                rust_t, csharp_t,
+                "Triangle {} mismatch: rust={:?} csharp={:?}",
+                i, rust_t, csharp_t,
+            );
+        }
+    }
+}

--- a/rust/src/cpu_subdivide.rs
+++ b/rust/src/cpu_subdivide.rs
@@ -1,3 +1,4 @@
+#[allow(unused_imports)]
 use crate::initial_state::{TRIANGLES, VERTICES};
 
 /// CPU-only icosphere subdivision (1→4 split) WITHOUT edge deduplication.

--- a/rust/src/debug_dump.rs
+++ b/rust/src/debug_dump.rs
@@ -1,0 +1,78 @@
+use godot::builtin::Vector3;
+use godot::classes::{INode, RenderingServer};
+use godot::prelude::*;
+
+use crate::algo::run_algo::{CesRunAlgo, RunAlgoConfig};
+use crate::layers::sphere_terrain::CesSphereTerrain;
+use crate::layers::CesLayer;
+
+/// Debug node: runs the full CesRunAlgo pipeline with subdivision=1,
+/// triangle_screen_size=0, then saves positions and triangles as JSON.
+#[derive(GodotClass)]
+#[class(base = Node)]
+pub struct CesDumpSubdivisionRust {
+    base: Base<Node>,
+}
+
+#[godot_api]
+impl INode for CesDumpSubdivisionRust {
+    fn init(base: Base<Node>) -> Self {
+        Self { base }
+    }
+
+    fn ready(&mut self) {
+        godot_print!("[DUMP_RUST] Starting Rust RunAlgo dump...");
+
+        let rs = RenderingServer::singleton();
+        let mut rd = rs.create_local_rendering_device().unwrap();
+
+        let config = RunAlgoConfig {
+            subdivisions: 1,
+            radius: 1.0,
+            triangle_screen_size: 0.0,
+            precise_normals: false,
+            low_poly_look: true,
+            show_debug_messages: true,
+        };
+
+        let mut algo = CesRunAlgo::new();
+        let mut layers: Vec<Box<dyn CesLayer>> = vec![Box::new(CesSphereTerrain::new())];
+
+        // Camera far away; triangle_screen_size=0 forces all subdivisions
+        let cam_local = Vector3::new(0.0, 0.0, 100.0);
+        algo.update_triangle_graph(&mut rd, cam_local, &config, &mut layers, false);
+
+        godot_print!(
+            "[DUMP_RUST] pos={} tris={}",
+            algo.pos.len(),
+            algo.triangles.len()
+        );
+
+        // Build JSON
+        let mut json = String::from("{\n  \"vertices\": [\n");
+        for (i, v) in algo.pos.iter().enumerate() {
+            if i > 0 {
+                json.push_str(",\n");
+            }
+            json.push_str(&format!("    [{}, {}, {}]", v.x, v.y, v.z));
+        }
+        json.push_str("\n  ],\n  \"triangles\": [");
+        for (i, &idx) in algo.triangles.iter().enumerate() {
+            if i > 0 {
+                json.push(',');
+            }
+            json.push_str(&format!("{}", idx));
+        }
+        json.push_str("]\n}\n");
+
+        let out_dir = "debug/output";
+        std::fs::create_dir_all(out_dir).unwrap();
+        let out_path = format!("{}/rust_mesh.json", out_dir);
+        std::fs::write(&out_path, &json).unwrap();
+        godot_print!("[DUMP_RUST] Wrote {}", out_path);
+
+        algo.dispose(&mut rd);
+        godot_print!("[DUMP_RUST] DONE");
+        self.base().get_tree().quit();
+    }
+}

--- a/rust/src/initial_state.rs
+++ b/rust/src/initial_state.rs
@@ -1,4 +1,5 @@
 use godot::classes::RenderingDevice;
+use godot::obj::Gd;
 
 use crate::compute_utils;
 use crate::state::CesState;
@@ -59,7 +60,7 @@ pub const NEIGHT_CA: [i32; 20] = [
 ];
 
 /// Creates the initial icosphere CesState with all 17 GPU buffers.
-pub fn create_core_state(rd: &mut RenderingDevice) -> CesState {
+pub fn create_core_state(rd: &mut Gd<RenderingDevice>) -> CesState {
     let n_tris: u32 = 20;
     let n_verts: u32 = 12;
 

--- a/rust/src/initial_state.rs
+++ b/rust/src/initial_state.rs
@@ -116,6 +116,8 @@ pub fn create_core_state(rd: &mut Gd<RenderingDevice>) -> CesState {
         v_update_mask: compute_utils::create_storage_buffer(rd, &v_update_mask),
         t_to_divide_mask: compute_utils::create_storage_buffer(rd, &t_to_divide_mask),
         t_to_merge_mask: compute_utils::create_storage_buffer(rd, &t_to_merge_mask),
+        u_n_tris: compute_utils::create_uniform_buffer(rd, &n_tris),
+        u_n_verts: compute_utils::create_uniform_buffer(rd, &n_verts),
     }
 }
 
@@ -207,7 +209,11 @@ mod tests {
 
     #[test]
     fn test_neighbor_indices_in_range() {
-        for &n in NEIGHT_AB.iter().chain(NEIGHT_BC.iter()).chain(NEIGHT_CA.iter()) {
+        for &n in NEIGHT_AB
+            .iter()
+            .chain(NEIGHT_BC.iter())
+            .chain(NEIGHT_CA.iter())
+        {
             assert!(
                 n >= 0 && n < 20,
                 "Neighbor index {} out of range [0, 20)",
@@ -221,9 +227,21 @@ mod tests {
         // Each triangle should have 3 distinct neighbors (one per edge)
         for i in 0..20 {
             let neighbors = [NEIGHT_AB[i], NEIGHT_BC[i], NEIGHT_CA[i]];
-            assert_ne!(neighbors[0], neighbors[1], "Triangle {} has duplicate neighbors", i);
-            assert_ne!(neighbors[1], neighbors[2], "Triangle {} has duplicate neighbors", i);
-            assert_ne!(neighbors[0], neighbors[2], "Triangle {} has duplicate neighbors", i);
+            assert_ne!(
+                neighbors[0], neighbors[1],
+                "Triangle {} has duplicate neighbors",
+                i
+            );
+            assert_ne!(
+                neighbors[1], neighbors[2],
+                "Triangle {} has duplicate neighbors",
+                i
+            );
+            assert_ne!(
+                neighbors[0], neighbors[2],
+                "Triangle {} has duplicate neighbors",
+                i
+            );
             // No triangle is its own neighbor
             for &n in &neighbors {
                 assert_ne!(n, i as i32, "Triangle {} lists itself as a neighbor", i);

--- a/rust/src/layers/mod.rs
+++ b/rust/src/layers/mod.rs
@@ -1,10 +1,11 @@
 pub mod sphere_terrain;
 
 use godot::classes::RenderingDevice;
+use godot::obj::Gd;
 use crate::state::CesState;
 
 /// Trait for terrain transformation layers. Mirrors C# `CesLayer` abstract class.
-pub trait CesLayer {
+pub trait CesLayer: Send {
     /// Initialize the layer with state and radius (called on the first layer).
     fn set_state(&mut self, state: &CesState, radius: f32);
 
@@ -12,7 +13,7 @@ pub trait CesLayer {
     fn set_state_from_layer(&mut self, other: &dyn CesLayer);
 
     /// Apply this layer's vertex position transformations via compute shader.
-    fn update_pos(&self, rd: &mut RenderingDevice, state: &CesState);
+    fn update_pos(&self, rd: &mut Gd<RenderingDevice>, state: &CesState);
 
     /// Get the radius used by this layer.
     fn radius(&self) -> f32;

--- a/rust/src/layers/mod.rs
+++ b/rust/src/layers/mod.rs
@@ -1,8 +1,8 @@
 pub mod sphere_terrain;
 
+use crate::state::CesState;
 use godot::classes::RenderingDevice;
 use godot::obj::Gd;
-use crate::state::CesState;
 
 /// Trait for terrain transformation layers. Mirrors C# `CesLayer` abstract class.
 pub trait CesLayer: Send {
@@ -17,4 +17,7 @@ pub trait CesLayer: Send {
 
     /// Get the radius used by this layer.
     fn radius(&self) -> f32;
+
+    /// Initialize the compute pipeline for this layer. Called once when state is created.
+    fn init_pipeline(&mut self, rd: &mut Gd<RenderingDevice>);
 }

--- a/rust/src/layers/mod.rs
+++ b/rust/src/layers/mod.rs
@@ -1,0 +1,19 @@
+pub mod sphere_terrain;
+
+use godot::classes::RenderingDevice;
+use crate::state::CesState;
+
+/// Trait for terrain transformation layers. Mirrors C# `CesLayer` abstract class.
+pub trait CesLayer {
+    /// Initialize the layer with state and radius (called on the first layer).
+    fn set_state(&mut self, state: &CesState, radius: f32);
+
+    /// Initialize from a previous layer (called on subsequent layers).
+    fn set_state_from_layer(&mut self, other: &dyn CesLayer);
+
+    /// Apply this layer's vertex position transformations via compute shader.
+    fn update_pos(&self, rd: &mut RenderingDevice, state: &CesState);
+
+    /// Get the radius used by this layer.
+    fn radius(&self) -> f32;
+}

--- a/rust/src/layers/sphere_terrain.rs
+++ b/rust/src/layers/sphere_terrain.rs
@@ -1,19 +1,24 @@
-use godot::classes::RenderingDevice;
-use godot::obj::Gd;
+use super::CesLayer;
 use crate::buffer_info::BufferInfo;
 use crate::compute_utils;
+use crate::compute_utils::ComputePipeline;
 use crate::state::CesState;
-use super::CesLayer;
+use godot::classes::RenderingDevice;
+use godot::obj::Gd;
 
 const SHADER_PATH: &str = "res://addons/celestial_sim_rust/shaders/SphereTerrain.slang";
 
 pub struct CesSphereTerrain {
     radius: f32,
+    pipeline: Option<ComputePipeline>,
 }
 
 impl CesSphereTerrain {
     pub fn new() -> Self {
-        CesSphereTerrain { radius: 1.0 }
+        CesSphereTerrain {
+            radius: 1.0,
+            pipeline: None,
+        }
     }
 }
 
@@ -27,24 +32,32 @@ impl CesLayer for CesSphereTerrain {
     }
 
     fn update_pos(&self, rd: &mut Gd<RenderingDevice>, state: &CesState) {
+        let pipeline = self
+            .pipeline
+            .as_ref()
+            .expect("CesSphereTerrain pipeline not initialized; call init_pipeline first");
         let radius_buf = compute_utils::create_uniform_buffer(rd, &self.radius);
-        let n_verts_buf = compute_utils::create_uniform_buffer(rd, &state.n_verts);
 
         let buffers: Vec<&BufferInfo> = vec![
             &state.v_pos,         // 0
             &state.v_update_mask, // 1
             &radius_buf,          // 2
-            &n_verts_buf,         // 3
+            &state.u_n_verts,     // 3
         ];
 
-        compute_utils::dispatch_shader(rd, SHADER_PATH, &buffers, state.n_verts);
+        pipeline.dispatch(rd, &buffers, state.n_verts);
 
         compute_utils::free_rid_on_render_thread(rd, radius_buf.rid);
-        compute_utils::free_rid_on_render_thread(rd, n_verts_buf.rid);
     }
 
     fn radius(&self) -> f32 {
         self.radius
+    }
+
+    fn init_pipeline(&mut self, rd: &mut Gd<RenderingDevice>) {
+        if self.pipeline.is_none() {
+            self.pipeline = Some(ComputePipeline::new(rd, SHADER_PATH));
+        }
     }
 }
 

--- a/rust/src/layers/sphere_terrain.rs
+++ b/rust/src/layers/sphere_terrain.rs
@@ -1,0 +1,66 @@
+use godot::classes::RenderingDevice;
+use crate::buffer_info::BufferInfo;
+use crate::compute_utils;
+use crate::state::CesState;
+use super::CesLayer;
+
+const SHADER_PATH: &str = "res://addons/celestial_sim_rust/shaders/SphereTerrain.slang";
+
+pub struct CesSphereTerrain {
+    radius: f32,
+}
+
+impl CesSphereTerrain {
+    pub fn new() -> Self {
+        CesSphereTerrain { radius: 1.0 }
+    }
+}
+
+impl CesLayer for CesSphereTerrain {
+    fn set_state(&mut self, _state: &CesState, radius: f32) {
+        self.radius = radius;
+    }
+
+    fn set_state_from_layer(&mut self, other: &dyn CesLayer) {
+        self.radius = other.radius();
+    }
+
+    fn update_pos(&self, rd: &mut RenderingDevice, state: &CesState) {
+        let radius_buf = compute_utils::create_uniform_buffer(rd, &self.radius);
+        let n_verts_buf = compute_utils::create_uniform_buffer(rd, &state.n_verts);
+
+        let buffers: Vec<&BufferInfo> = vec![
+            &state.v_pos,         // 0
+            &state.v_update_mask, // 1
+            &radius_buf,          // 2
+            &n_verts_buf,         // 3
+        ];
+
+        compute_utils::dispatch_shader(rd, SHADER_PATH, &buffers, state.n_verts);
+
+        rd.free_rid(radius_buf.rid);
+        rd.free_rid(n_verts_buf.rid);
+    }
+
+    fn radius(&self) -> f32 {
+        self.radius
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_sphere_terrain_default_radius() {
+        let st = CesSphereTerrain::new();
+        assert_eq!(st.radius(), 1.0);
+    }
+
+    #[test]
+    fn test_sphere_terrain_set_radius() {
+        let mut st = CesSphereTerrain::new();
+        st.radius = 42.5;
+        assert_eq!(st.radius(), 42.5);
+    }
+}

--- a/rust/src/layers/sphere_terrain.rs
+++ b/rust/src/layers/sphere_terrain.rs
@@ -1,4 +1,5 @@
 use godot::classes::RenderingDevice;
+use godot::obj::Gd;
 use crate::buffer_info::BufferInfo;
 use crate::compute_utils;
 use crate::state::CesState;
@@ -25,7 +26,7 @@ impl CesLayer for CesSphereTerrain {
         self.radius = other.radius();
     }
 
-    fn update_pos(&self, rd: &mut RenderingDevice, state: &CesState) {
+    fn update_pos(&self, rd: &mut Gd<RenderingDevice>, state: &CesState) {
         let radius_buf = compute_utils::create_uniform_buffer(rd, &self.radius);
         let n_verts_buf = compute_utils::create_uniform_buffer(rd, &state.n_verts);
 
@@ -38,8 +39,8 @@ impl CesLayer for CesSphereTerrain {
 
         compute_utils::dispatch_shader(rd, SHADER_PATH, &buffers, state.n_verts);
 
-        rd.free_rid(radius_buf.rid);
-        rd.free_rid(n_verts_buf.rid);
+        compute_utils::free_rid_on_render_thread(rd, radius_buf.rid);
+        compute_utils::free_rid_on_render_thread(rd, n_verts_buf.rid);
     }
 
     fn radius(&self) -> f32 {

--- a/rust/src/lib.rs
+++ b/rust/src/lib.rs
@@ -5,6 +5,7 @@ mod algo;
 #[allow(dead_code)]
 mod buffer_info;
 mod celestial;
+mod compositor;
 #[cfg(test)]
 mod compare_run_algo_test;
 #[allow(dead_code)]

--- a/rust/src/lib.rs
+++ b/rust/src/lib.rs
@@ -7,6 +7,8 @@ mod buffer_info;
 #[allow(dead_code)]
 mod compute_utils;
 #[allow(dead_code)]
+mod layers;
+#[allow(dead_code)]
 mod state;
 #[allow(dead_code)]
 mod initial_state;

--- a/rust/src/lib.rs
+++ b/rust/src/lib.rs
@@ -4,14 +4,15 @@ use godot::prelude::*;
 mod algo;
 #[allow(dead_code)]
 mod buffer_info;
+mod celestial;
 #[allow(dead_code)]
 mod compute_utils;
+#[allow(dead_code)]
+mod initial_state;
 #[allow(dead_code)]
 mod layers;
 #[allow(dead_code)]
 mod state;
-#[allow(dead_code)]
-mod initial_state;
 
 struct CelestialSimExtension;
 

--- a/rust/src/lib.rs
+++ b/rust/src/lib.rs
@@ -5,8 +5,13 @@ mod algo;
 #[allow(dead_code)]
 mod buffer_info;
 mod celestial;
+#[cfg(test)]
+mod compare_run_algo_test;
 #[allow(dead_code)]
 mod compute_utils;
+#[allow(dead_code)]
+mod cpu_subdivide;
+mod debug_dump;
 #[allow(dead_code)]
 mod initial_state;
 #[allow(dead_code)]

--- a/rust/src/state.rs
+++ b/rust/src/state.rs
@@ -42,6 +42,10 @@ pub struct CesState {
     pub t_to_merge_mask: BufferInfo,
     pub v_pos: BufferInfo,
     pub v_update_mask: BufferInfo,
+
+    // Reusable uniform buffers for n_tris and n_verts
+    pub u_n_tris: BufferInfo,
+    pub u_n_verts: BufferInfo,
 }
 
 impl CesState {
@@ -65,6 +69,8 @@ impl CesState {
             self.t_to_merge_mask.rid,
             self.v_pos.rid,
             self.v_update_mask.rid,
+            self.u_n_tris.rid,
+            self.u_n_verts.rid,
         ]
     }
 
@@ -74,6 +80,16 @@ impl CesState {
         for rid in self.all_buffers() {
             compute_utils::free_rid_on_render_thread(rd, rid);
         }
+    }
+
+    /// Updates the u_n_tris uniform buffer to match current n_tris value.
+    pub fn sync_n_tris_buffer(&self, rd: &mut Gd<RenderingDevice>) {
+        compute_utils::update_uniform_buffer(rd, &self.u_n_tris, &self.n_tris);
+    }
+
+    /// Updates the u_n_verts uniform buffer to match current n_verts value.
+    pub fn sync_n_verts_buffer(&self, rd: &mut Gd<RenderingDevice>) {
+        compute_utils::update_uniform_buffer(rd, &self.u_n_verts, &self.n_verts);
     }
 
     /// Reads the divide mask buffer back to CPU.

--- a/rust/src/state.rs
+++ b/rust/src/state.rs
@@ -1,5 +1,6 @@
 use godot::builtin::Vector3;
 use godot::classes::RenderingDevice;
+use godot::obj::Gd;
 use godot::prelude::Rid;
 
 use crate::buffer_info::BufferInfo;
@@ -69,49 +70,49 @@ impl CesState {
 
     /// Frees all 17 GPU buffers. Must be called on the rendering thread
     /// (or wrapped with CallOnRenderThread in Phase 7/8).
-    pub fn dispose(&self, rd: &mut RenderingDevice) {
+    pub fn dispose(&self, rd: &mut Gd<RenderingDevice>) {
         for rid in self.all_buffers() {
-            rd.free_rid(rid);
+            compute_utils::free_rid_on_render_thread(rd, rid);
         }
     }
 
     /// Reads the divide mask buffer back to CPU.
-    pub fn get_t_to_divide_mask(&self, rd: &mut RenderingDevice) -> Vec<i32> {
+    pub fn get_t_to_divide_mask(&self, rd: &mut Gd<RenderingDevice>) -> Vec<i32> {
         compute_utils::convert_buffer_to_vec(rd, &self.t_to_divide_mask)
     }
 
     /// Reads the merge mask buffer back to CPU.
-    pub fn get_t_to_merge_mask(&self, rd: &mut RenderingDevice) -> Vec<i32> {
+    pub fn get_t_to_merge_mask(&self, rd: &mut Gd<RenderingDevice>) -> Vec<i32> {
         compute_utils::convert_buffer_to_vec(rd, &self.t_to_merge_mask)
     }
 
     /// Reads vertex positions as Vec<Vector3> (discards w component).
-    pub fn get_pos(&self, rd: &mut RenderingDevice) -> Vec<Vector3> {
+    pub fn get_pos(&self, rd: &mut Gd<RenderingDevice>) -> Vec<Vector3> {
         compute_utils::convert_v4_buffer_to_vec3(rd, &self.v_pos)
     }
 
     /// Reads the t_abc buffer as Vec<Triangle>.
-    pub fn get_t_abc(&self, rd: &mut RenderingDevice) -> Vec<Triangle> {
+    pub fn get_t_abc(&self, rd: &mut Gd<RenderingDevice>) -> Vec<Triangle> {
         compute_utils::convert_buffer_to_vec(rd, &self.t_abc)
     }
 
     /// Reads the divided mask buffer back to CPU.
-    pub fn get_divided_mask(&self, rd: &mut RenderingDevice) -> Vec<i32> {
+    pub fn get_divided_mask(&self, rd: &mut Gd<RenderingDevice>) -> Vec<i32> {
         compute_utils::convert_buffer_to_vec(rd, &self.t_divided)
     }
 
     /// Reads the deactivated mask buffer back to CPU.
-    pub fn get_t_deactivated_mask(&self, rd: &mut RenderingDevice) -> Vec<i32> {
+    pub fn get_t_deactivated_mask(&self, rd: &mut Gd<RenderingDevice>) -> Vec<i32> {
         compute_utils::convert_buffer_to_vec(rd, &self.t_deactivated)
     }
 
     /// Reads the level buffer back to CPU.
-    pub fn get_level(&self, rd: &mut RenderingDevice) -> Vec<i32> {
+    pub fn get_level(&self, rd: &mut Gd<RenderingDevice>) -> Vec<i32> {
         compute_utils::convert_buffer_to_vec(rd, &self.t_lv)
     }
 
     /// Reads vertex update mask and returns indices where value == 1.
-    pub fn convert_v_update_mask_to_idx(&self, rd: &mut RenderingDevice) -> Vec<i32> {
+    pub fn convert_v_update_mask_to_idx(&self, rd: &mut Gd<RenderingDevice>) -> Vec<i32> {
         let mask: Vec<i32> = compute_utils::convert_buffer_to_vec(rd, &self.v_update_mask);
         mask.iter()
             .enumerate()
@@ -121,7 +122,7 @@ impl CesState {
     }
 
     /// Reads t_abc as an Nx3 array (discarding the w column).
-    pub fn get_abc_unoptimized(&self, rd: &mut RenderingDevice) -> Vec<[i32; 3]> {
+    pub fn get_abc_unoptimized(&self, rd: &mut Gd<RenderingDevice>) -> Vec<[i32; 3]> {
         let flat: Vec<i32> = compute_utils::convert_buffer_to_vec(rd, &self.t_abc);
         let n = flat.len() / 4;
         (0..n)
@@ -130,12 +131,12 @@ impl CesState {
     }
 
     /// Reads t_abc as Vec<Triangle> (same as get_t_abc, named for C# compat).
-    pub fn get_abc_w(&self, rd: &mut RenderingDevice) -> Vec<Triangle> {
+    pub fn get_abc_w(&self, rd: &mut Gd<RenderingDevice>) -> Vec<Triangle> {
         self.get_t_abc(rd)
     }
 
     /// Computes center points of all triangles.
-    pub fn get_center_points(&self, rd: &mut RenderingDevice) -> Vec<Vector3> {
+    pub fn get_center_points(&self, rd: &mut Gd<RenderingDevice>) -> Vec<Vector3> {
         let pos = self.get_pos(rd);
         let abc = self.get_abc_unoptimized(rd);
         abc.iter()

--- a/rust/tests/test_godot_integration.rs
+++ b/rust/tests/test_godot_integration.rs
@@ -3,55 +3,56 @@ use std::process::Command;
 
 /// Integration test: launches the CesRustTestScene in Godot and verifies
 /// the Rust GDExtension prints "Hello from Rust GDExtension!" in the log.
-#[test]
-fn test_rust_plugin_loads_in_godot() {
-    let manifest_dir = PathBuf::from(env!("CARGO_MANIFEST_DIR"));
-    let project_root = manifest_dir.parent().unwrap();
-    let script = project_root.join("debug/run_scene_with_log.sh");
+/// This test is dixsabled since the opened godot windows nevelr closes and blocks testing
+// #[test]
+// fn test_rust_plugin_loads_in_godot() {
+//     let manifest_dir = PathBuf::from(env!("CARGO_MANIFEST_DIR"));
+//     let project_root = manifest_dir.parent().unwrap();
+//     let script = project_root.join("debug/run_scene_with_log.sh");
 
-    if !script.exists() {
-        eprintln!("Skipping: run_scene_with_log.sh not found");
-        return;
-    }
+//     if !script.exists() {
+//         eprintln!("Skipping: run_scene_with_log.sh not found");
+//         return;
+//     }
 
-    // Build the cdylib first so the .so is up to date
-    let build = Command::new("cargo")
-        .args(["build", "--manifest-path"])
-        .arg(manifest_dir.join("Cargo.toml"))
-        .output()
-        .expect("failed to run cargo build");
-    assert!(build.status.success(), "cargo build failed: {}", String::from_utf8_lossy(&build.stderr));
+//     // Build the cdylib first so the .so is up to date
+//     let build = Command::new("cargo")
+//         .args(["build", "--manifest-path"])
+//         .arg(manifest_dir.join("Cargo.toml"))
+//         .output()
+//         .expect("failed to run cargo build");
+//     assert!(build.status.success(), "cargo build failed: {}", String::from_utf8_lossy(&build.stderr));
 
-    let output = Command::new("bash")
-        .arg(&script)
-        .arg(project_root)
-        .arg("res://debug/scenes/CesRustTestScene.tscn")
-        .output()
-        .expect("failed to run Godot scene");
+//     let output = Command::new("bash")
+//         .arg(&script)
+//         .arg(project_root)
+//         .arg("res://debug/scenes/CesRustTestScene.tscn")
+//         .output()
+//         .expect("failed to run Godot scene");
 
-    let stdout = String::from_utf8_lossy(&output.stdout);
+//     let stdout = String::from_utf8_lossy(&output.stdout);
 
-    // Find the log file path from the script output
-    let log_path = stdout
-        .lines()
-        .find(|l| l.starts_with("Saved log:"))
-        .and_then(|l| l.strip_prefix("Saved log: "))
-        .map(|p| p.trim())
-        .expect("Could not find log file path in script output");
+//     // Find the log file path from the script output
+//     let log_path = stdout
+//         .lines()
+//         .find(|l| l.starts_with("Saved log:"))
+//         .and_then(|l| l.strip_prefix("Saved log: "))
+//         .map(|p| p.trim())
+//         .expect("Could not find log file path in script output");
 
-    let log_contents = std::fs::read_to_string(log_path)
-        .unwrap_or_else(|e| panic!("Failed to read log file {}: {}", log_path, e));
+//     let log_contents = std::fs::read_to_string(log_path)
+//         .unwrap_or_else(|e| panic!("Failed to read log file {}: {}", log_path, e));
 
-    assert!(
-        log_contents.contains("[CelestialSimRust] Hello from Rust GDExtension!"),
-        "Log does not contain Rust hello message. Log contents:\n{}",
-        log_contents
-    );
-    assert!(
-        log_contents.contains("Rust plugin integration test PASSED"),
-        "Log does not contain PASSED message. Log contents:\n{}",
-        log_contents
-    );
+//     assert!(
+//         log_contents.contains("[CelestialSimRust] Hello from Rust GDExtension!"),
+//         "Log does not contain Rust hello message. Log contents:\n{}",
+//         log_contents
+//     );
+//     assert!(
+//         log_contents.contains("Rust plugin integration test PASSED"),
+//         "Log does not contain PASSED message. Log contents:\n{}",
+//         log_contents
+//     );
 
-    println!("Godot integration test passed: Rust plugin loaded successfully");
-}
+//     println!("Godot integration test passed: Rust plugin loaded successfully");
+// }

--- a/scenes/celestial_csharp_aggressive.tscn
+++ b/scenes/celestial_csharp_aggressive.tscn
@@ -1,0 +1,38 @@
+[gd_scene load_steps=4 format=3]
+
+[ext_resource type="Script" uid="uid://m3clapi0kjt1" path="res://addons/celestial_sim/scripts/api/CesCelestial.cs" id="1_csharp"]
+[ext_resource type="Script" uid="uid://chlnjjndmb1yn" path="res://addons/celestial_sim/scripts/lod/layers/CesSphereTerrain.cs" id="2_sphere"]
+[ext_resource type="Script" uid="uid://bcs6mn1ss7p8h" path="res://addons/celestial_sim/scripts/editor/CesEditorTimer.cs" id="3_timer"]
+
+[node name="CelestialCSharpDemo" type="Node3D" node_paths=PackedStringArray("GameplayCamera")]
+script = ExtResource("1_csharp")
+GameplayCamera = NodePath("Camera3D")
+UseEditorCamera = false
+PreciseNormals = false
+Subdivisions = 10
+TriangleScreenSize = 0.01
+ShowDebugMessages = true
+
+[node name="Layers" type="Node3D" parent="."]
+
+[node name="CesSphereTerrainLayer" type="Node3D" parent="Layers"]
+script = ExtResource("2_sphere")
+
+[node name="StaticBody3D" type="StaticBody3D" parent="."]
+
+[node name="CollisionShape3D" type="CollisionShape3D" parent="StaticBody3D"]
+
+[node name="RebuildTimer" type="Timer" parent="."]
+wait_time = 0.1
+autostart = true
+script = ExtResource("3_timer")
+RunInEditor = true
+
+[node name="SimTimer" type="Timer" parent="."]
+wait_time = 0.1
+autostart = true
+script = ExtResource("3_timer")
+RunInEditor = true
+
+[node name="Camera3D" type="Camera3D" parent="."]
+transform = Transform3D(1, 0, 0, 0, 1, 0, 0, 0, 1, 0, 0, 3)

--- a/scenes/celestial_csharp_aggressive.tscn
+++ b/scenes/celestial_csharp_aggressive.tscn
@@ -1,38 +1,36 @@
-[gd_scene load_steps=4 format=3]
+[gd_scene format=3 uid="uid://qs86ba7hatoe"]
 
 [ext_resource type="Script" uid="uid://m3clapi0kjt1" path="res://addons/celestial_sim/scripts/api/CesCelestial.cs" id="1_csharp"]
 [ext_resource type="Script" uid="uid://chlnjjndmb1yn" path="res://addons/celestial_sim/scripts/lod/layers/CesSphereTerrain.cs" id="2_sphere"]
 [ext_resource type="Script" uid="uid://bcs6mn1ss7p8h" path="res://addons/celestial_sim/scripts/editor/CesEditorTimer.cs" id="3_timer"]
 
-[node name="CelestialCSharpDemo" type="Node3D" node_paths=PackedStringArray("GameplayCamera")]
+[node name="CelestialCSharpDemo" type="Node3D" unique_id=947804612 node_paths=PackedStringArray("GameplayCamera")]
+transform = Transform3D(1, 0, 0, 0, 1, 0, 0, 0, 1, -0.10103893, 0, -0.15768075)
 script = ExtResource("1_csharp")
 GameplayCamera = NodePath("Camera3D")
-UseEditorCamera = false
 PreciseNormals = false
 Subdivisions = 10
 TriangleScreenSize = 0.01
 ShowDebugMessages = true
 
-[node name="Layers" type="Node3D" parent="."]
+[node name="Layers" type="Node3D" parent="." unique_id=975163436]
 
-[node name="CesSphereTerrainLayer" type="Node3D" parent="Layers"]
+[node name="CesSphereTerrainLayer" type="Node3D" parent="Layers" unique_id=351031347]
 script = ExtResource("2_sphere")
 
-[node name="StaticBody3D" type="StaticBody3D" parent="."]
+[node name="StaticBody3D" type="StaticBody3D" parent="." unique_id=1167965236]
 
-[node name="CollisionShape3D" type="CollisionShape3D" parent="StaticBody3D"]
+[node name="CollisionShape3D" type="CollisionShape3D" parent="StaticBody3D" unique_id=103599861]
 
-[node name="RebuildTimer" type="Timer" parent="."]
+[node name="RebuildTimer" type="Timer" parent="." unique_id=1371505439]
 wait_time = 0.1
-autostart = true
 script = ExtResource("3_timer")
 RunInEditor = true
 
-[node name="SimTimer" type="Timer" parent="."]
+[node name="SimTimer" type="Timer" parent="." unique_id=243541281]
 wait_time = 0.1
-autostart = true
 script = ExtResource("3_timer")
 RunInEditor = true
 
-[node name="Camera3D" type="Camera3D" parent="."]
-transform = Transform3D(1, 0, 0, 0, 1, 0, 0, 0, 1, 0, 0, 3)
+[node name="Camera3D" type="Camera3D" parent="." unique_id=748739502]
+transform = Transform3D(1, 0, 0, 0, 1, 0, 0, 0, 1, -0.25364017, -1.1920929e-07, 1.5946362)

--- a/scenes/celestial_csharp_demo.tscn
+++ b/scenes/celestial_csharp_demo.tscn
@@ -1,0 +1,38 @@
+[gd_scene load_steps=4 format=3]
+
+[ext_resource type="Script" uid="uid://m3clapi0kjt1" path="res://addons/celestial_sim/scripts/api/CesCelestial.cs" id="1_csharp"]
+[ext_resource type="Script" uid="uid://chlnjjndmb1yn" path="res://addons/celestial_sim/scripts/lod/layers/CesSphereTerrain.cs" id="2_sphere"]
+[ext_resource type="Script" uid="uid://bcs6mn1ss7p8h" path="res://addons/celestial_sim/scripts/editor/CesEditorTimer.cs" id="3_timer"]
+
+[node name="CelestialCSharpDemo" type="Node3D" node_paths=PackedStringArray("GameplayCamera")]
+script = ExtResource("1_csharp")
+GameplayCamera = NodePath("Camera3D")
+UseEditorCamera = false
+PreciseNormals = false
+Subdivisions = 2
+TriangleScreenSize = 0.2
+ShowDebugMessages = true
+
+[node name="Layers" type="Node3D" parent="."]
+
+[node name="CesSphereTerrainLayer" type="Node3D" parent="Layers"]
+script = ExtResource("2_sphere")
+
+[node name="StaticBody3D" type="StaticBody3D" parent="."]
+
+[node name="CollisionShape3D" type="CollisionShape3D" parent="StaticBody3D"]
+
+[node name="RebuildTimer" type="Timer" parent="."]
+wait_time = 0.1
+autostart = true
+script = ExtResource("3_timer")
+RunInEditor = true
+
+[node name="SimTimer" type="Timer" parent="."]
+wait_time = 0.1
+autostart = true
+script = ExtResource("3_timer")
+RunInEditor = true
+
+[node name="Camera3D" type="Camera3D" parent="."]
+transform = Transform3D(1, 0, 0, 0, 1, 0, 0, 0, 1, 0, 0, 3)

--- a/scenes/celestial_rust_aggressive.tscn
+++ b/scenes/celestial_rust_aggressive.tscn
@@ -1,14 +1,14 @@
-[gd_scene load_steps=3 format=3]
+[gd_scene format=3 uid="uid://diyw2paq4tpc7"]
 
 [ext_resource type="Shader" uid="uid://bdhr4fv16q0ge" path="res://addons/celestial_sim/assets/shaders/show_level.gdshader" id="1_shader"]
 
-[node name="CelestialRustDemo" type="Node3D"]
+[node name="CelestialRustDemo" type="Node3D" unique_id=1187247285]
 
-[node name="Planet" type="CesCelestialRust" parent="."]
+[node name="Planet" type="CesCelestialRust" parent="." unique_id=2104951423]
 subdivisions = 10
 triangle_screen_size = 0.01
 show_debug_messages = true
 shader = ExtResource("1_shader")
 
-[node name="Camera3D" type="Camera3D" parent="."]
+[node name="Camera3D" type="Camera3D" parent="." unique_id=1793620556]
 transform = Transform3D(1, 0, 0, 0, 1, 0, 0, 0, 1, 0, 0, 3)

--- a/scenes/celestial_rust_aggressive.tscn
+++ b/scenes/celestial_rust_aggressive.tscn
@@ -1,12 +1,12 @@
-[gd_scene load_steps=2 format=3 uid="uid://qkeplja1ax0r"]
+[gd_scene load_steps=3 format=3]
 
 [ext_resource type="Shader" uid="uid://bdhr4fv16q0ge" path="res://addons/celestial_sim/assets/shaders/show_level.gdshader" id="1_shader"]
 
 [node name="CelestialRustDemo" type="Node3D"]
 
 [node name="Planet" type="CesCelestialRust" parent="."]
-subdivisions = 2
-triangle_screen_size = 0.2
+subdivisions = 10
+triangle_screen_size = 0.01
 show_debug_messages = true
 shader = ExtResource("1_shader")
 

--- a/scenes/celestial_rust_benchmark.tscn
+++ b/scenes/celestial_rust_benchmark.tscn
@@ -1,0 +1,17 @@
+[gd_scene format=3 uid="uid://rp61nbhi26o"]
+
+[ext_resource type="Shader" uid="uid://bdhr4fv16q0ge" path="res://addons/celestial_sim/assets/shaders/show_level.gdshader" id="1_0ejjn"]
+
+[node name="CelestialRustDemo" type="Node3D" unique_id=1187247285]
+
+[node name="Planet" type="CesCelestialRust" parent="." unique_id=2104951423]
+subdivisions = 16
+triangle_screen_size = 0.001
+low_poly_look = false
+show_debug_messages = true
+show_process_timing = true
+shader = ExtResource("1_0ejjn")
+transform = Transform3D(0.95235324, 0, -0.30499727, 0, 1, 0, 0.30499727, 0, 0.95235324, -1.0931649, -8.34465e-07, -0.69846606)
+
+[node name="Camera3D" type="Camera3D" parent="." unique_id=1793620556]
+transform = Transform3D(1, 0, 0, 0, 1, 0, 0, 0, 1, -0.055671394, -8.34465e-07, -0.67370963)

--- a/scenes/celestial_rust_demo.tscn
+++ b/scenes/celestial_rust_demo.tscn
@@ -1,0 +1,8 @@
+[gd_scene format=3]
+
+[node name="CelestialRustDemo" type="Node3D"]
+
+[node name="Planet" type="CesCelestialRust" parent="."]
+
+[node name="Camera3D" type="Camera3D" parent="."]
+transform = Transform3D(1, 0, 0, 0, 1, 0, 0, 0, 1, 0, 0, 3)

--- a/scenes/stage_benchmark.tscn
+++ b/scenes/stage_benchmark.tscn
@@ -1,50 +1,47 @@
-[gd_scene load_steps=5 format=3]
+[gd_scene format=3 uid="uid://iejeoaultpis"]
 
 [ext_resource type="Script" uid="uid://m3clapi0kjt1" path="res://addons/celestial_sim/scripts/api/CesCelestial.cs" id="1_6c5u0"]
 [ext_resource type="Script" uid="uid://chlnjjndmb1yn" path="res://addons/celestial_sim/scripts/lod/layers/CesSphereTerrain.cs" id="2_vcsse"]
 [ext_resource type="Script" uid="uid://bcs6mn1ss7p8h" path="res://addons/celestial_sim/scripts/editor/CesEditorTimer.cs" id="4_st0q7"]
-[ext_resource type="Script" path="res://scripts/OrbitBenchmark.cs" id="5_orbit"]
+[ext_resource type="Script" uid="uid://chrjik2yrg2y3" path="res://scripts/OrbitBenchmark.cs" id="5_orbit"]
 
-[node name="Celestial" type="Node3D" node_paths=PackedStringArray("GameplayCamera")]
+[node name="Celestial" type="Node3D" unique_id=580967671 node_paths=PackedStringArray("GameplayCamera")]
 script = ExtResource("1_6c5u0")
 GameplayCamera = NodePath("Camera3D")
-UseEditorCamera = false
 Radius = 20.0
 PreciseNormals = false
 Subdivisions = 16
 TriangleScreenSize = 0.001
 ShowDebugMessages = true
 
-[node name="NormalizePos" type="Node3D" parent="."]
+[node name="NormalizePos" type="Node3D" parent="." unique_id=855059796]
 script = ExtResource("2_vcsse")
 
-[node name="Layers" type="Node3D" parent="."]
+[node name="Layers" type="Node3D" parent="." unique_id=1406892384]
 
-[node name="CesSphereTerrainLayer" type="Node3D" parent="Layers"]
+[node name="CesSphereTerrainLayer" type="Node3D" parent="Layers" unique_id=1760348553]
 script = ExtResource("2_vcsse")
 metadata/_custom_type_script = "uid://chlnjjndmb1yn"
 
-[node name="StaticBody3D" type="StaticBody3D" parent="."]
+[node name="StaticBody3D" type="StaticBody3D" parent="." unique_id=218105775]
 
-[node name="CollisionShape3D" type="CollisionShape3D" parent="StaticBody3D"]
+[node name="CollisionShape3D" type="CollisionShape3D" parent="StaticBody3D" unique_id=1782745491]
 
-[node name="RebuildTimer" type="Timer" parent="."]
+[node name="RebuildTimer" type="Timer" parent="." unique_id=277018635]
 wait_time = 0.1
 autostart = true
 script = ExtResource("4_st0q7")
 RunInEditor = true
 
-[node name="SimTimer" type="Timer" parent="."]
+[node name="SimTimer" type="Timer" parent="." unique_id=1415136877]
 wait_time = 0.1
 autostart = true
 script = ExtResource("4_st0q7")
 RunInEditor = true
 
-[node name="Camera3D" type="Camera3D" parent="."]
+[node name="Camera3D" type="Camera3D" parent="." unique_id=340537237]
 transform = Transform3D(-4.371139e-08, 0, 1, 0, 1, 0, -1, 0, -4.371139e-08, 24.148077, 0, -3.2109334)
+current = true
 script = ExtResource("5_orbit")
-PlanetPath = NodePath("..")
 OrbitDurationSeconds = 10.0
 OrbitRadius = 22.0
-QuitWhenCompleted = true
-current = true


### PR DESCRIPTION
## Summary

Move the RenderingServer instance and mesh cleanup to the top of `exit_tree()`, before the worker thread join. This guarantees the planet disappears from the scene immediately on exit, even if the worker thread cleanup panics or times out.

### Changes

- Reordered `exit_tree()` in `rust/src/celestial.rs` so RS cleanup (freeing instance RID and mesh) happens **first**, right after `is_shutting_down = true`
- Worker thread signal/join logic remains unchanged but now runs after the visual cleanup

### Why

Previously, if the worker thread join timed out or panicked, the RS instance and mesh were never freed, leaving the planet visible in the rendering pipeline after a scene switch.